### PR TITLE
修复中文输入法输入内容丢失

### DIFF
--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -235,7 +235,11 @@ struct NoteTextView: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let tv = scroll.documentView as? NSTextView else { return }
-        if tv.string != text {
+        // Never replace the string while an IME owns a marked-text range.
+        // SwiftUI can update this view from the autosave publisher while a
+        // Chinese/Japanese composition is still active; assigning `string`
+        // then discards the composition and makes typed text appear to vanish.
+        if !tv.hasMarkedText(), tv.string != text {
             tv.string = text
             Self.styleTasks(tv, ink: ink, size: fontSize)
         }
@@ -256,6 +260,11 @@ struct NoteTextView: NSViewRepresentable {
     /// inserted in the *previous* font and immediately rewritten, which reads as
     /// the text jumping under the cursor after a font or size change.
     static func styleTasks(_ tv: NSTextView, ink: NSColor, size: CGFloat = 13.5) {
+        // TextKit mutations and selection restoration are not safe while the
+        // input method is composing marked text. The next textDidChange after
+        // the composition is committed will style the complete document.
+        guard !tv.hasMarkedText() else { return }
+
         let font = bodyFont(size)
         tv.typingAttributes = [.font: font, .foregroundColor: ink]
 


### PR DESCRIPTION
## 摘要
- 修复中文/日文输入法处于 marked text 组合阶段时，输入内容被重写后丢失的问题。
- 避免 SwiftUI 自动保存更新覆盖输入法正在编辑的组合文本。
- 避免在输入法组合期间执行 TextKit Markdown 重排和光标恢复。

## 测试
- [x] `./build.sh debug`
- [x] `./build.sh release`
- [x] `codesign --verify --deep --strict build/Noty.app`
- [ ] 使用中文输入法实际输入并提交候选词

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scrollable note switcher above the expanded editor while preserving the editor’s vertical position when changing notes.
  * Added Chinese labels for note colors, deck styles, settings options, and keyboard shortcuts.
* **Localization**
  * Translated menus, tooltips, dialogs, settings, library views, export/import messages, undo notifications, and update alerts into Chinese.
* **Bug Fixes**
  * Improved Chinese and Japanese text input by preventing interruptions during composition.
  * Deferred note styling until text composition is committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->