### PR TITLE
Let the deck stay fanned out instead of folding back to the pill

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -71,6 +71,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         deckManager.refreshAll()
     }
 
+    @objc func toggleDeckAlwaysShown() {
+        Settings.deckAlwaysShown.toggle()
+        deckManager.refreshAll()
+    }
+
     @objc func toggleDeckEdge() {
         Settings.deckOnLeftEdge.toggle()
         deckManager.refreshAll()

--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -36,6 +36,7 @@ final class DeckModel: ObservableObject {
 
     // Mirrored from Settings so SwiftUI re-renders when a preference flips.
     @Published var style: DeckStyle = Settings.deckStyle
+    @Published var alwaysShown: Bool = Settings.deckAlwaysShown
     @Published var onLeftEdge: Bool = Settings.deckOnLeftEdge
     @Published var fontSize: Double = Settings.noteFontSize
     @Published var markdown: Bool = Settings.markdownStyling
@@ -47,6 +48,7 @@ final class DeckModel: ObservableObject {
 
     func syncPreferences() {
         style = Settings.deckStyle
+        alwaysShown = Settings.deckAlwaysShown
         onLeftEdge = Settings.deckOnLeftEdge
         fontSize = Settings.noteFontSize
         markdown = Settings.markdownStyling
@@ -75,6 +77,10 @@ final class DeckController: NSObject {
 
     weak var manager: DeckManager?
 
+    /// Where the deck sits when nothing is happening: the pill, or the tabs
+    /// themselves once the user has asked for them to stay put.
+    private var restingState: DeckState { Settings.deckAlwaysShown ? .fan : .rest }
+
     var screen: NSScreen? {
         NSScreen.screens.first {
             ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value == displayID
@@ -95,6 +101,7 @@ final class DeckController: NSObject {
         container.addSubview(hosting)
 
         panel.contentView = container
+        model.state = restingState
         layout()
         panel.orderFrontRegardless()
 
@@ -195,8 +202,11 @@ final class DeckController: NSObject {
         } else {
             removeKeyMonitor(); removeOutsideMonitor()
         }
-        if new == .rest { stopIdleWatch() } else { startIdleWatch() }
-        if new == .rest { model.showAll = false; model.findQuery = nil }
+        // A deck that is already at rest has nothing to tidy away, so the poll
+        // only runs above the resting state — with the tabs kept open, that means
+        // it runs for an open note and not for the fan.
+        if new.rank > restingState.rank { startIdleWatch() } else { stopIdleWatch() }
+        if new == restingState { model.showAll = false; model.findQuery = nil }
     }
 
     /// Anything the user does keeps the deck awake.
@@ -259,14 +269,14 @@ final class DeckController: NSObject {
     }
 
     func pointerExited() {
-        guard model.state == .fan else { return }   // an open note stays open until Esc
+        guard model.state == .fan, restingState != .fan else { return }   // an open note stays open until Esc
         // Tracking areas fire spuriously across a resize, so confirm the pointer really left.
         exitWork?.cancel()
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.model.state == .fan else { return }
             if !self.hotZone.contains(NSEvent.mouseLocation) {
                 DeckLog.line("pointerExited confirmed")
-                self.setState(.rest)
+                self.setState(self.restingState)
             }
         }
         exitWork = work
@@ -290,7 +300,7 @@ final class DeckController: NSObject {
             // If the pointer is already away from the edge, the deck follows it
             // shut on the next poll rather than hanging around.
         } else {
-            setState(.rest)
+            setState(restingState)
         }
     }
 
@@ -304,11 +314,30 @@ final class DeckController: NSObject {
     /// Dismiss the whole deck, note and tabs together.
     func dismiss() {
         let wasExpanded = model.state.expandedID != nil
-        setState(.rest)
+        setState(restingState)
         if wasExpanded { NSApp.deactivate() }
     }
 
-    func collapseToRest() { setState(.rest) }
+    func collapseToRest() { setState(restingState) }
+
+    /// Adopt a change to the preference: fan out, or fall back to the pill once
+    /// the pointer is off the deck. Called after Settings writes it.
+    func applyRestingState() {
+        switch model.state {
+        case .rest where restingState == .fan:
+            setState(.fan)
+        case .fan where restingState == .rest:
+            // The pointer may still be on the deck, and yanking the tabs out from
+            // under it reads as a glitch. Restart the idle poll instead and let it
+            // fold the deck away the moment the pointer leaves — without this the
+            // fan stays stuck open, because the poll is not running while the deck
+            // is at its resting state.
+            if hotZone.contains(NSEvent.mouseLocation) { startIdleWatch() }
+            else { setState(.rest) }
+        default:
+            break
+        }
+    }
 
     // MARK: Key handling for the expanded note
 
@@ -425,6 +454,11 @@ final class DeckController: NSObject {
         textItem.submenu = textMenu
         menu.addItem(textItem)
 
+        let keepOpen = NSMenuItem(title: "Keep deck open",
+                                  action: #selector(AppDelegate.toggleDeckAlwaysShown), keyEquivalent: "")
+        keepOpen.state = Settings.deckAlwaysShown ? .on : .off
+        menu.addItem(keepOpen)
+
         let leftEdge = NSMenuItem(title: "Dock deck to left edge",
                                   action: #selector(AppDelegate.toggleDeckEdge), keyEquivalent: "")
         leftEdge.state = Settings.deckOnLeftEdge ? .on : .off
@@ -503,7 +537,9 @@ final class DeckManager {
     }
 
     func refreshAll() {
-        decks.values.forEach { $0.model.syncPreferences(); $0.refreshLevel(); $0.layout() }
+        decks.values.forEach {
+            $0.model.syncPreferences(); $0.refreshLevel(); $0.layout(); $0.applyRestingState()
+        }
     }
 
     /// Deck on the screen holding the pointer, else the main screen's.

--- a/Sources/Settings.swift
+++ b/Sources/Settings.swift
@@ -140,6 +140,13 @@ enum Settings {
     static let fanIdleTimeout: TimeInterval = 4
     static let noteIdleTimeout: TimeInterval = 60
 
+    /// Keep the deck fanned out instead of letting it fall back to the pill.
+    /// Only the *resting* state changes — notes still open and tidy away as usual.
+    static var deckAlwaysShown: Bool {
+        get { d.bool(forKey: "deckAlwaysShown") }
+        set { d.set(newValue, forKey: "deckAlwaysShown") }
+    }
+
     /// Labelled tabs, or bare colour chips that barely touch the screen.
     static var deckStyle: DeckStyle {
         get { DeckStyle(rawValue: d.string(forKey: "deckStyle") ?? "") ?? .tabs }

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -99,6 +99,7 @@ struct ShortcutField: NSViewRepresentable {
 
 final class SettingsModel: ObservableObject {
     @Published var deckStyle: DeckStyle { didSet { Settings.deckStyle = deckStyle; apply() } }
+    @Published var alwaysShown: Bool    { didSet { Settings.deckAlwaysShown = alwaysShown; apply() } }
     @Published var onLeftEdge: Bool     { didSet { Settings.deckOnLeftEdge = onLeftEdge; apply() } }
     @Published var edgeWidth: Double    { didSet { Settings.edgeWidth = edgeWidth; apply() } }
     @Published var overFullScreen: Bool { didSet { Settings.showOverFullScreen = overFullScreen; apply() } }
@@ -126,6 +127,7 @@ final class SettingsModel: ObservableObject {
 
     init() {
         deckStyle = Settings.deckStyle
+        alwaysShown = Settings.deckAlwaysShown
         onLeftEdge = Settings.deckOnLeftEdge
         edgeWidth = Settings.edgeWidth
         overFullScreen = Settings.showOverFullScreen
@@ -247,6 +249,12 @@ struct SettingsView: View {
                             Text("How far from the edge the pointer wakes the deck — \(Int(model.edgeWidth)) pt.")
                                 .font(.system(size: 11)).foregroundStyle(.secondary)
                         }
+                    }
+                    VStack(alignment: .leading, spacing: 3) {
+                        Toggle("Keep the deck open", isOn: $model.alwaysShown)
+                        Text("Tabs stay on the edge with their labels showing, instead of folding back into the pill when the pointer leaves.")
+                            .font(.system(size: 11)).foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     Toggle("Show over full-screen apps", isOn: $model.overFullScreen)
                     Toggle("Launch at login", isOn: $model.launchAtLogin)


### PR DESCRIPTION
The tabs and their labels only exist while the pointer is on the edge, so a deck you want to read at a glance has to be hovered first. This adds a preference that keeps them there.

**Settings → Deck → Keep the deck open**, and a matching item in the deck's context menu next to *Dock deck to left edge*. Off by default, so nothing changes unless it's asked for.

### What actually changes

Only the deck's *resting* state. `DeckController` gains a `restingState` (`.fan` when the preference is on, `.rest` otherwise) and every path that used to hard-code `.rest` — `pointerExited`, `collapse`, `dismiss`, `collapseToRest` — now returns there instead. Notes open, close and idle away exactly as before.

Two details worth a look on review:

- **The idle poll now runs above the resting state, not above `.rest`.** It still tidies an open note away after a minute, but it no longer chases a fan that is meant to stay put — otherwise it would fire a collapse every 120 ms forever.
- **Toggling the preference back off while the pointer is on the deck restarts that poll** rather than pulling the tabs out from under the cursor. Without it the fan sticks open, because the poll isn't running while the deck sits at its resting state. Likely path, since the context-menu toggle puts the pointer right there.

### Trade-off

The panel keeps the same width in `.fan` as in `.expanded`, so with this on there is a permanently present full-height panel roughly 480 pt wide at the screen edge. That is unchanged behaviour — it is what the fan already does on hover — and blank regions stay click-through via `DeckContentView.hitTest`. Narrowing it for the resting fan is possible but means resizing the panel as a note opens, which the existing comment in `layout(for:)` warns produces the note-flying-in-from-mid-screen artifact. Left alone deliberately; happy to revisit if you'd rather it were tighter.

Built and compiles clean against `./build.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Keep the deck open” setting.
  - Decks can now remain expanded instead of collapsing into the pill state.
  - Added context-menu and preference controls for toggling this behavior.
  - Decks refresh immediately when the setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->