### PR TITLE
Add a deck size preference so the tabs can be scaled

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -71,6 +71,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         deckManager.refreshAll()
     }
 
+    @objc func setDeckScale(_ sender: NSMenuItem) {
+        guard let scale = sender.representedObject as? Double else { return }
+        Settings.deckScale = scale
+        deckManager.refreshAll()
+    }
+
     @objc func toggleDeckEdge() {
         Settings.deckOnLeftEdge.toggle()
         deckManager.refreshAll()

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -125,14 +125,17 @@ enum Ink {
 
     // Tab labels use the same face a shade bolder, so they hold up turned on
     // their side at this size.
-    static let tabSize: CGFloat = 9.5
-    static let tabTracking: CGFloat = 0.1
+    /// Labels scale with the deck, so a bigger tab carries a bigger title rather
+    /// than more empty paper. Layout measures the strip with this very font, so
+    /// the two cannot drift apart.
+    static var tabSize: CGFloat { 9.5 * DeckGeom.scale }
+    static var tabTracking: CGFloat { 0.1 * DeckGeom.scale }
 
     /// For measuring — layout sizes each tab's strip to the longest label.
     static var tabNSFont: NSFont {
         let f = face
         guard !f.tab.isEmpty, let font = NSFont(name: f.tab, size: tabSize + f.bump) else {
-            return .systemFont(ofSize: 9, weight: .semibold)
+            return .systemFont(ofSize: tabSize - 0.5, weight: .semibold)
         }
         return font
     }
@@ -140,7 +143,7 @@ enum Ink {
     static var tabFont: Font {
         let f = face
         guard !f.tab.isEmpty, NSFont(name: f.tab, size: tabSize) != nil else {
-            return .system(size: 9, weight: .semibold)
+            return .system(size: tabSize - 0.5, weight: .semibold)
         }
         return .custom(f.tab, size: tabSize + f.bump)
     }

--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -36,6 +36,9 @@ final class DeckModel: ObservableObject {
 
     // Mirrored from Settings so SwiftUI re-renders when a preference flips.
     @Published var style: DeckStyle = Settings.deckStyle
+    /// DeckGeom reads the scale straight from Settings; this mirror exists purely
+    /// so a change to it invalidates the views that measure against it.
+    @Published var scale: Double = Settings.deckScale
     @Published var onLeftEdge: Bool = Settings.deckOnLeftEdge
     @Published var fontSize: Double = Settings.noteFontSize
     @Published var markdown: Bool = Settings.markdownStyling
@@ -47,6 +50,7 @@ final class DeckModel: ObservableObject {
 
     func syncPreferences() {
         style = Settings.deckStyle
+        scale = Settings.deckScale
         onLeftEdge = Settings.deckOnLeftEdge
         fontSize = Settings.noteFontSize
         markdown = Settings.markdownStyling
@@ -424,6 +428,18 @@ final class DeckController: NSObject {
         }
         textItem.submenu = textMenu
         menu.addItem(textItem)
+
+        let sizeItem = NSMenuItem(title: "Deck size", action: nil, keyEquivalent: "")
+        let sizeMenu = NSMenu()
+        for entry in Settings.deckSizes {
+            let it = NSMenuItem(title: entry.name, action: #selector(AppDelegate.setDeckScale(_:)),
+                                keyEquivalent: "")
+            it.representedObject = entry.scale
+            it.state = abs(Settings.deckScale - entry.scale) < 0.01 ? .on : .off
+            sizeMenu.addItem(it)
+        }
+        sizeItem.submenu = sizeMenu
+        menu.addItem(sizeItem)
 
         let leftEdge = NSMenuItem(title: "Dock deck to left edge",
                                   action: #selector(AppDelegate.toggleDeckEdge), keyEquivalent: "")

--- a/Sources/DeckPanel.swift
+++ b/Sources/DeckPanel.swift
@@ -53,32 +53,40 @@ struct DeckLayout {
 }
 
 enum DeckGeom {
+    /// Every length below is expressed at 100% and passed through `s(_:)`, so one
+    /// preference resizes the deck as a whole. Rounding to whole points keeps the
+    /// shingled tabs from landing on half pixels and showing a seam.
+    static var scale: CGFloat { CGFloat(Settings.deckScale) }
+    private static func s(_ v: CGFloat) -> CGFloat { (v * scale).rounded() }
+
     // Rest — a 12 pt pill of colour dashes
-    static let pillWidth: CGFloat = 12
-    static let pillTouchWidth: CGFloat = 14
-    static let dashHeight: CGFloat = 14
-    static let dashWidth: CGFloat = 7
-    static let dashGap: CGFloat = 5
-    static let pillPad: CGFloat = 7
+    static var pillWidth: CGFloat { s(12) }
+    static var pillTouchWidth: CGFloat { s(14) }
+    static var dashHeight: CGFloat { s(14) }
+    static var dashWidth: CGFloat { s(7) }
+    static var dashGap: CGFloat { s(5) }
+    static var pillPad: CGFloat { s(7) }
     static let maxDashes = 14
 
     // Fan
-    static let tabWidth: CGFloat = 30
-    static let tabHeightMax: CGFloat = 118
-    static let tabHeightMin: CGFloat = 58
-    static let tabGap: CGFloat = 7
+    static var tabWidth: CGFloat { s(30) }
+    static var tabHeightMax: CGFloat { s(118) }
+    static var tabHeightMin: CGFloat { s(58) }
+    static var tabGap: CGFloat { s(7) }
     /// How far the next tab laps over the one before it.
-    static let tabLap: CGFloat = 40
-    static let pitchMin: CGFloat = 56
-    static let pitchMax: CGFloat = 106
+    static var tabLap: CGFloat { s(40) }
+    static var pitchMin: CGFloat { s(56) }
+    static var pitchMax: CGFloat { s(106) }
+    /// The smallest pitch the guard rail may squeeze a tab down to.
+    static var pitchFloor: CGFloat { s(36) }
     /// The strip is the label plus this much; the label is drawn inside it with
     /// `labelInset`. Keeping the two different is what leaves the last glyph room
     /// — sizing the strip to exactly the text width truncates on rounding.
-    static let labelPad: CGFloat = 20
-    static let labelInset: CGFloat = 12
+    static var labelPad: CGFloat { s(20) }
+    static var labelInset: CGFloat { s(12) }
     /// Tabs and notes are drawn a little past the screen edge so their lean cannot
     /// open a wedge of background between them and the edge they are stuck to.
-    static let bleed: CGFloat = 14
+    static var bleed: CGFloat { s(14) }
 
     /// Everything leans the same way — a deck of tabs at matching angles reads as
     /// deliberate, where per-note angles just look scattered.
@@ -93,21 +101,22 @@ enum DeckGeom {
         return text.size(withAttributes: [.font: Ink.tabNSFont]).width
             + Ink.tabTracking * CGFloat(text.length)
     }
-    static let chipWidth: CGFloat = 30
-    static let chipHeight: CGFloat = 24
-    static let chipGap: CGFloat = 6
-    static let fanWidth: CGFloat = 50
-    static let plusSize: CGFloat = 28
-    static let plusInset: CGFloat = 14
-    static let plusGap: CGFloat = 12
-    static let moreTabHeight: CGFloat = 34
+    static var chipWidth: CGFloat { s(30) }
+    static var chipHeight: CGFloat { s(24) }
+    static var chipGap: CGFloat { s(6) }
+    static var fanWidth: CGFloat { s(50) }
+    static var plusSize: CGFloat { s(28) }
+    static var plusInset: CGFloat { s(14) }
+    static var plusGap: CGFloat { s(12) }
+    static var moreTabHeight: CGFloat { s(34) }
 
     /// The deck may claim at most this much of the screen before tabs start shrinking.
     static let heightBudget: CGFloat = 0.68
 
     /// The open note carries its own tab as a left gutter, so it reads as
-    /// growing out of the deck rather than floating beside it.
-    static let gutterWidth: CGFloat = 30
+    /// growing out of the deck rather than floating beside it. It matches the tab
+    /// it grew from, so it scales with one.
+    static var gutterWidth: CGFloat { tabWidth }
 
     // Expanded — the note slides clear of the deck
     static let editorWidth: CGFloat = 460
@@ -140,7 +149,7 @@ enum DeckGeom {
             let reserved = hasMore ? moreTabHeight + tabGap : 0
             let budget = panelHeight * heightBudget - reserved
             if CGFloat(n) * pitch + tabLap > budget {
-                pitch = max(36, (budget - tabLap) / CGFloat(n))
+                pitch = max(pitchFloor, (budget - tabLap) / CGFloat(n))
             }
             return DeckLayout(itemHeight: pitch + tabLap, pitch: pitch,
                               moreGap: tabGap, moreHeight: moreTabHeight,

--- a/Sources/Settings.swift
+++ b/Sources/Settings.swift
@@ -140,6 +140,24 @@ enum Settings {
     static let fanIdleTimeout: TimeInterval = 4
     static let noteIdleTimeout: TimeInterval = 60
 
+    /// Multiplier on every deck metric — tab width, label type, the lap between
+    /// tabs, the chips and the pill. One knob so the deck scales as a whole
+    /// instead of drifting out of proportion with itself.
+    static let deckScaleRange: ClosedRange<Double> = 0.7...1.8
+
+    static let deckSizes: [(name: String, scale: Double)] = [
+        ("Small", 0.85), ("Default", 1.0), ("Large", 1.25), ("Extra large", 1.5)
+    ]
+
+    static var deckScale: Double {
+        get {
+            let v = d.double(forKey: "deckScale")
+            return deckScaleRange.contains(v) ? v : 1.0
+        }
+        set { d.set(min(max(newValue, deckScaleRange.lowerBound), deckScaleRange.upperBound),
+                    forKey: "deckScale") }
+    }
+
     /// Labelled tabs, or bare colour chips that barely touch the screen.
     static var deckStyle: DeckStyle {
         get { DeckStyle(rawValue: d.string(forKey: "deckStyle") ?? "") ?? .tabs }

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -99,6 +99,7 @@ struct ShortcutField: NSViewRepresentable {
 
 final class SettingsModel: ObservableObject {
     @Published var deckStyle: DeckStyle { didSet { Settings.deckStyle = deckStyle; apply() } }
+    @Published var deckScale: Double    { didSet { Settings.deckScale = deckScale; apply() } }
     @Published var onLeftEdge: Bool     { didSet { Settings.deckOnLeftEdge = onLeftEdge; apply() } }
     @Published var edgeWidth: Double    { didSet { Settings.edgeWidth = edgeWidth; apply() } }
     @Published var overFullScreen: Bool { didSet { Settings.showOverFullScreen = overFullScreen; apply() } }
@@ -126,6 +127,7 @@ final class SettingsModel: ObservableObject {
 
     init() {
         deckStyle = Settings.deckStyle
+        deckScale = Settings.deckScale
         onLeftEdge = Settings.deckOnLeftEdge
         edgeWidth = Settings.edgeWidth
         overFullScreen = Settings.showOverFullScreen
@@ -233,6 +235,20 @@ struct SettingsView: View {
                         Picker("", selection: $model.deckStyle) {
                             ForEach(DeckStyle.allCases, id: \.self) { Text($0.title).tag($0) }
                         }.labelsHidden().pickerStyle(.segmented).frame(width: 240)
+                    }
+                    row("Size") {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 10) {
+                                Slider(value: $model.deckScale,
+                                       in: Settings.deckScaleRange.lowerBound...Settings.deckScaleRange.upperBound,
+                                       step: 0.05).frame(width: 210)
+                                Text("\(Int((model.deckScale * 100).rounded()))%")
+                                    .font(.system(size: 11).monospacedDigit())
+                                    .foregroundStyle(.secondary).frame(width: 52, alignment: .leading)
+                            }
+                            Text("Scales the tabs, their labels, the chips and the resting pill together.")
+                                .font(.system(size: 11)).foregroundStyle(.secondary)
+                        }
                     }
                     row("Edge") {
                         Picker("", selection: $model.onLeftEdge) {


### PR DESCRIPTION
Every deck metric was a fixed constant, so the tabs were whatever size they were — small to read on a dense display, large on a small one. This puts them on one multiplier.

**Settings → Deck → Size** (slider, 70–180%, live percentage), plus a *Deck size* submenu in the deck's context menu with Small / Default / Large / Extra large, mirroring how *Text size* already works. Defaults to 100%, so nothing moves unless it's asked for.

### Approach

`DeckGeom` keeps its numbers written at 100% and passes each through one `s(_:)` helper, rounded to whole points so the shingled tabs don't land on half pixels and show a seam. Tab width, the lap, the pitch bounds, label padding, bleed, chips, the plus button, the more-tab and the resting pill all go through it. `gutterWidth` becomes `tabWidth` outright — the open note's gutter *is* the tab it grew from, so they should never diverge.

Two details worth a look on review:

- **`Ink.tabSize` scales too, and that is what carries the pitch.** Layout already sizes each tab's uncovered strip from the *measured* label width, so scaling the type widens the strip for free — no second knob, no chance of the strip and the label disagreeing.
- **The `System` face has no bold cut**, so `tabNSFont`/`tabFont` always fall through to the hard-coded 9 pt system fallback for it. Those now scale as well, or `System` would be the one face that quietly ignored the setting.

The guard rail that shrinks the pitch on a short display had a bare `max(36, …)` floor; that is now `pitchFloor` and scales with the rest, so a large deck on a short screen shrinks proportionally rather than to a size its own labels no longer fit.

`DeckModel` mirrors the scale as a `@Published` purely to invalidate the views that measure against it — `DeckGeom` still reads `Settings` directly.

Built and compiles clean against `./build.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deck size control to Settings, with adjustable scaling from 70% to 180%.
  - Added preset deck sizes to the deck context menu.
  - Deck dimensions, tabs, labels, chips, and spacing now adjust consistently with the selected size.
  - Deck size preferences are saved and applied across all open decks.
- **Improvements**
  - Tab typography and minimum layout spacing now scale with the selected deck size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->