### PR TITLE
Improve editor input performance with incremental styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ and macOS 15+.
 ./build.sh                   # release build → build/Noty.app
 ./build.sh debug             # fast, unoptimised
 ./build.sh release run       # build, then relaunch
+./scripts/test-editor.sh     # focused editor range/style/input regression checks
 open build/Noty.app
 ```
 

--- a/Sources/EditorStyleEngine.swift
+++ b/Sources/EditorStyleEngine.swift
@@ -1,0 +1,265 @@
+import AppKit
+
+extension NSAttributedString.Key {
+    /// Marks Markdown punctuation that should occupy no glyph space while the
+    /// plain-text source remains untouched.
+    static let notyHidden = NSAttributedString.Key("notyHidden")
+}
+
+/// Accumulates TextKit character edits until it is safe to style them.
+/// Marked-text composition deliberately leaves the pending ranges untouched.
+struct EditorEditAccumulator {
+    private(set) var pending: [NSRange] = []
+
+    var hasPendingEdits: Bool { !pending.isEmpty }
+
+    mutating func record(_ range: NSRange) {
+        guard range.location != NSNotFound, range.location >= 0, range.length >= 0 else { return }
+        pending.append(range)
+    }
+
+    mutating func consume(in text: NSString, hasMarkedText: Bool) -> [NSRange] {
+        guard !hasMarkedText, !pending.isEmpty else { return [] }
+        let edits = pending
+        pending.removeAll(keepingCapacity: true)
+        return EditorStyleEngine.affectedLineRanges(for: edits, in: text)
+    }
+
+    mutating func clear() {
+        pending.removeAll(keepingCapacity: true)
+    }
+}
+
+/// Applies note attributes without owning editor state. Every normal edit is
+/// planned as one or more complete-line ranges; full-document work is reserved
+/// for initial content and explicit configuration changes.
+enum EditorStyleEngine {
+    typealias FontProvider = (CGFloat) -> NSFont
+    typealias CompletedTaskPredicate = (String) -> Bool
+
+    private static let heading = try! NSRegularExpression(
+        pattern: "^(#{1,6})[ \\t]+(.+)$", options: [.anchorsMatchLines])
+    private static let bold = try! NSRegularExpression(
+        pattern: "(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1")
+    private static let italic = try! NSRegularExpression(
+        pattern: "(?<![\\*_])([\\*_])(?=[^\\*_\\s])(.+?)(?<=[^\\*_\\s])\\1(?![\\*_])")
+    private static let code = try! NSRegularExpression(pattern: "`([^`\\n]+)`")
+    private static let struck = try! NSRegularExpression(
+        pattern: "~~(?=\\S)(.+?)(?<=\\S)~~")
+    private static let quote = try! NSRegularExpression(
+        pattern: "^>[ \\t]?(.*)$", options: [.anchorsMatchLines])
+    private static let bullet = try! NSRegularExpression(
+        pattern: "^[ \\t]*([-*+])[ \\t]+", options: [.anchorsMatchLines])
+
+    /// The complete line containing a UTF-16 location. At EOF after a trailing
+    /// newline this correctly returns the zero-length final line.
+    static func lineRange(containing location: Int, in text: NSString) -> NSRange {
+        let safeLocation = min(max(0, location), text.length)
+        return text.lineRange(for: NSRange(location: safeLocation, length: 0))
+    }
+
+    /// Expand character edits to complete lines. One character on either side
+    /// is included before expansion so inserting/deleting a newline restyles
+    /// both paragraphs that changed identity.
+    static func affectedLineRanges(for edits: [NSRange], in text: NSString) -> [NSRange] {
+        guard !edits.isEmpty else { return [] }
+        guard text.length > 0 else { return [NSRange(location: 0, length: 0)] }
+
+        let expanded = edits.compactMap { edit -> NSRange? in
+            guard let safe = clamped(edit, to: text.length) else { return nil }
+            let lower = max(0, safe.location - 1)
+            let upper = min(text.length, safe.location + safe.length + 1)
+            return text.lineRange(for: NSRange(location: lower, length: upper - lower))
+        }
+        return merged(expanded, length: text.length, keepingEmpty: false)
+    }
+
+    /// Clamp, sort, and merge only overlapping or adjacent ranges. Distant
+    /// caret lines stay disjoint so styling never scans the gap between them.
+    static func normalizedStyleRanges(_ ranges: [NSRange], length: Int) -> [NSRange] {
+        merged(ranges, length: length, keepingEmpty: false)
+    }
+
+    /// Apply base, Markdown, and completed-task attributes to scoped ranges.
+    /// The string and selection are never mutated.
+    @discardableResult
+    static func apply(to textView: NSTextView,
+                      ranges: [NSRange],
+                      revealing activeLine: NSRange?,
+                      ink: NSColor,
+                      size: CGFloat,
+                      markdownEnabled: Bool,
+                      bodyFont: @escaping FontProvider,
+                      isCompletedTask: @escaping CompletedTaskPredicate) -> [NSRange] {
+        let font = bodyFont(size)
+        textView.typingAttributes = [.font: font, .foregroundColor: ink]
+
+        guard let storage = textView.textStorage else { return [] }
+        let planned = normalizedStyleRanges(ranges, length: storage.length)
+        guard !planned.isEmpty else { return [] }
+
+        for range in planned {
+            // Process disjoint ranges separately. NSTextStorage coalesces edits
+            // inside one begin/end pair, which would otherwise invalidate the
+            // untouched gap between two distant caret lines.
+            storage.beginEditing()
+            storage.removeAttribute(.strikethroughStyle, range: range)
+            storage.removeAttribute(.obliqueness, range: range)
+            storage.removeAttribute(.backgroundColor, range: range)
+            storage.removeAttribute(.notyHidden, range: range)
+            storage.addAttribute(.foregroundColor, value: ink, range: range)
+            storage.addAttribute(.font, value: font, range: range)
+
+            let fragment = storage.mutableString.substring(with: range)
+            if markdownEnabled {
+                markdown(storage, fragment, offset: range.location, ink: ink,
+                         size: size, revealing: activeLine, bodyFont: bodyFont)
+            }
+            styleCompletedTasks(storage, fragment, offset: range.location,
+                                ink: ink, isCompletedTask: isCompletedTask)
+            storage.endEditing()
+
+            // Hidden markers require glyph regeneration, but only for the lines
+            // whose attributes were actually touched.
+            textView.layoutManager?.invalidateGlyphs(forCharacterRange: range,
+                                                      changeInLength: 0,
+                                                      actualCharacterRange: nil)
+            textView.layoutManager?.invalidateLayout(forCharacterRange: range,
+                                                      actualCharacterRange: nil)
+            textView.layoutManager?.invalidateDisplay(forCharacterRange: range)
+        }
+        return planned
+    }
+
+    private static func markdown(_ storage: NSTextStorage, _ fragment: String,
+                                 offset: Int, ink: NSColor, size: CGFloat,
+                                 revealing activeLine: NSRange?,
+                                 bodyFont: @escaping FontProvider) {
+        let local = fragment as NSString
+        let full = NSRange(location: 0, length: local.length)
+        let faint = ink.withAlphaComponent(0.32)
+
+        func global(_ range: NSRange) -> NSRange {
+            NSRange(location: offset + range.location, length: range.length)
+        }
+
+        /// Punctuation is hidden unless it intersects the active caret line.
+        func dim(_ localRange: NSRange) {
+            let range = global(localRange)
+            if let activeLine,
+               NSIntersectionRange(range, activeLine).length > 0 || activeLine.location == range.location {
+                storage.addAttribute(.foregroundColor, value: faint, range: range)
+            } else {
+                storage.addAttribute(.notyHidden, value: true, range: range)
+                storage.addAttribute(.foregroundColor, value: faint, range: range)
+            }
+        }
+
+        func each(_ expression: NSRegularExpression,
+                  _ body: @escaping (NSTextCheckingResult) -> Void) {
+            expression.enumerateMatches(in: fragment, range: full) { match, _, _ in
+                if let match { body(match) }
+            }
+        }
+
+        each(heading) { match in
+            let level = match.range(at: 1).length
+            let bump = max(1.5, 7 - CGFloat(level) * 1.1)
+            storage.addAttribute(.font, value: heavier(size + bump, bodyFont: bodyFont),
+                                 range: global(match.range))
+            dim(match.range(at: 1))
+        }
+        each(bold) { match in
+            storage.addAttribute(.font, value: heavier(size, bodyFont: bodyFont),
+                                 range: global(match.range(at: 2)))
+            dim(NSRange(location: match.range.location, length: 2))
+            dim(NSRange(location: match.range.upperBound - 2, length: 2))
+        }
+        each(italic) { match in
+            storage.addAttribute(.obliqueness, value: 0.2,
+                                 range: global(match.range(at: 2)))
+            dim(NSRange(location: match.range.location, length: 1))
+            dim(NSRange(location: match.range.upperBound - 1, length: 1))
+        }
+        each(code) { match in
+            storage.addAttribute(.font,
+                                 value: NSFont.monospacedSystemFont(ofSize: size - 0.5,
+                                                                    weight: .regular),
+                                 range: global(match.range(at: 1)))
+            storage.addAttribute(.backgroundColor, value: ink.withAlphaComponent(0.07),
+                                 range: global(match.range(at: 1)))
+            dim(NSRange(location: match.range.location, length: 1))
+            dim(NSRange(location: match.range.upperBound - 1, length: 1))
+        }
+        each(struck) { match in
+            storage.addAttribute(.strikethroughStyle,
+                                 value: NSUnderlineStyle.single.rawValue,
+                                 range: global(match.range(at: 1)))
+            dim(NSRange(location: match.range.location, length: 2))
+            dim(NSRange(location: match.range.upperBound - 2, length: 2))
+        }
+        each(quote) { match in
+            storage.addAttribute(.foregroundColor, value: ink.withAlphaComponent(0.62),
+                                 range: global(match.range))
+            storage.addAttribute(.obliqueness, value: 0.15,
+                                 range: global(match.range(at: 1)))
+            dim(NSRange(location: match.range.location, length: 1))
+        }
+        each(bullet) { match in
+            storage.addAttribute(.foregroundColor, value: ink.withAlphaComponent(0.5),
+                                 range: global(match.range(at: 1)))
+        }
+    }
+
+    private static func styleCompletedTasks(_ storage: NSTextStorage, _ fragment: String,
+                                            offset: Int, ink: NSColor,
+                                            isCompletedTask: @escaping CompletedTaskPredicate) {
+        let local = fragment as NSString
+        let full = NSRange(location: 0, length: local.length)
+        local.enumerateSubstrings(in: full, options: .byLines) { line, range, _, _ in
+            guard let line, isCompletedTask(line) else { return }
+            let global = NSRange(location: offset + range.location, length: range.length)
+            storage.addAttribute(.strikethroughStyle,
+                                 value: NSUnderlineStyle.single.rawValue, range: global)
+            storage.addAttribute(.foregroundColor,
+                                 value: ink.withAlphaComponent(0.45), range: global)
+        }
+    }
+
+    private static func heavier(_ size: CGFloat, bodyFont: FontProvider) -> NSFont {
+        let base = bodyFont(size)
+        let boldFont = NSFontManager.shared.convert(base, toHaveTrait: .boldFontMask)
+        return boldFont != base ? boldFont : NSFont.systemFont(ofSize: size, weight: .semibold)
+    }
+
+    private static func clamped(_ range: NSRange, to length: Int) -> NSRange? {
+        guard range.location != NSNotFound, range.location >= 0, range.length >= 0 else { return nil }
+        let location = min(range.location, length)
+        let available = length - location
+        return NSRange(location: location, length: min(range.length, available))
+    }
+
+    private static func merged(_ ranges: [NSRange], length: Int,
+                               keepingEmpty: Bool) -> [NSRange] {
+        let safe = ranges.compactMap { clamped($0, to: length) }
+            .filter { keepingEmpty || $0.length > 0 }
+            .sorted {
+                $0.location == $1.location ? $0.length < $1.length : $0.location < $1.location
+            }
+        guard var current = safe.first else { return [] }
+
+        var result: [NSRange] = []
+        for next in safe.dropFirst() {
+            if next.location <= current.location + current.length {
+                let upper = max(current.location + current.length,
+                                next.location + next.length)
+                current.length = upper - current.location
+            } else {
+                result.append(current)
+                current = next
+            }
+        }
+        result.append(current)
+        return result
+    }
+}

--- a/Sources/LibraryWindow.swift
+++ b/Sources/LibraryWindow.swift
@@ -276,7 +276,8 @@ struct LibraryDetail: View {
             .background(pal.dash.opacity(0.12))
 
             NoteTextView(text: $text, ink: NSColor(pal.ink), bridge: bridge,
-                         autofocus: false, fontSize: Settings.noteFontSize)
+                         autofocus: false, fontSize: Settings.noteFontSize,
+                         markdownEnabled: Settings.markdownStyling)
                 .background(pal.paper)
         }
         .onAppear { text = note.body }

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -75,12 +75,6 @@ final class EditorBridge: ObservableObject {
     }
 }
 
-extension NSAttributedString.Key {
-    /// Marks Markdown punctuation that should take up no space on screen while
-    /// staying in the text storage, so what is saved is what was typed.
-    static let notyHidden = NSAttributedString.Key("notyHidden")
-}
-
 /// Collapses glyphs carrying `.notyHidden` to nothing. This is the only way to
 /// hide characters without deleting them: colouring them clear still leaves
 /// their width behind, and the caret still walks through them.
@@ -131,10 +125,23 @@ final class TaskTextView: NSTextView {
 
     override func resetCursorRects() {
         super.resetCursorRects()
-        guard let lm = layoutManager, let tc = textContainer else { return }
-        let ns = string as NSString
+        guard let lm = layoutManager, let tc = textContainer,
+              let storage = textStorage else { return }
+        let ns = storage.mutableString
+        guard ns.length > 0, !visibleRect.isEmpty else { return }
+
         let origin = textContainerOrigin
-        ns.enumerateSubstrings(in: NSRange(location: 0, length: ns.length),
+        var containerVisible = visibleRect
+        containerVisible.origin.x -= origin.x
+        containerVisible.origin.y -= origin.y
+        let visibleGlyphs = lm.glyphRange(forBoundingRect: containerVisible, in: tc)
+        let visibleCharacters = lm.characterRange(forGlyphRange: visibleGlyphs,
+                                                   actualGlyphRange: nil)
+        let safeLocation = min(visibleCharacters.location, ns.length)
+        let safeLength = min(visibleCharacters.length, ns.length - safeLocation)
+        let lines = ns.lineRange(for: NSRange(location: safeLocation, length: safeLength))
+
+        ns.enumerateSubstrings(in: lines,
                                options: .byLines) { sub, range, _, _ in
             guard let sub, Tasks.isTask(sub) else { return }
             let glyphs = lm.glyphRange(forCharacterRange: NSRange(location: range.location, length: 1),
@@ -181,6 +188,7 @@ struct NoteTextView: NSViewRepresentable {
     let bridge: EditorBridge
     var autofocus: Bool
     var fontSize: CGFloat = 13.5
+    var markdownEnabled: Bool = Settings.markdownStyling
 
     static func bodyFont(_ size: CGFloat) -> NSFont { Ink.body(size) }
 
@@ -226,7 +234,15 @@ struct NoteTextView: NSViewRepresentable {
 
         scroll.documentView = tv
         bridge.textView = tv
-        Self.styleTasks(tv, ink: ink, size: fontSize)
+        let activeLine = EditorStyleEngine.lineRange(
+            containing: tv.selectedRange().location, in: storage.mutableString)
+        Self.applyStyles(to: tv,
+                         ranges: [NSRange(location: 0, length: storage.length)],
+                         revealing: activeLine,
+                         ink: ink,
+                         size: fontSize,
+                         markdownEnabled: markdownEnabled)
+        context.coordinator.attach(to: tv)
         if autofocus {
             DispatchQueue.main.async { tv.window?.makeFirstResponder(tv) }
         }
@@ -235,172 +251,206 @@ struct NoteTextView: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let tv = scroll.documentView as? NSTextView else { return }
-        if tv.string != text {
-            tv.string = text
-            Self.styleTasks(tv, ink: ink, size: fontSize)
-        }
-        let want = Self.bodyFont(fontSize)
-        if tv.textColor != ink || tv.font != want {
-            tv.textColor = ink
-            tv.insertionPointColor = ink
-            tv.font = want
-            Self.styleTasks(tv, ink: ink, size: fontSize)
-        }
+        context.coordinator.parent = self
+        context.coordinator.synchronize(tv)
         if bridge.textView !== tv { bridge.textView = tv }
     }
 
-    /// Dim and strike through anything already ticked off.
-    /// Restyling touches the whole document, which happens on every keystroke.
-    /// Two things make that safe: the caret has to be put back afterwards, and
-    /// `typingAttributes` has to be refreshed — otherwise the next character is
-    /// inserted in the *previous* font and immediately rewritten, which reads as
-    /// the text jumping under the cursor after a font or size change.
-    static func styleTasks(_ tv: NSTextView, ink: NSColor, size: CGFloat = 13.5) {
-        let font = bodyFont(size)
-        tv.typingAttributes = [.font: font, .foregroundColor: ink]
-
-        guard let storage = tv.textStorage else { return }
-        let full = NSRange(location: 0, length: storage.length)
-        guard full.length > 0 else { return }
-        let caret = tv.selectedRange()
-        storage.beginEditing()
-        storage.removeAttribute(.strikethroughStyle, range: full)
-        storage.removeAttribute(.obliqueness, range: full)
-        storage.removeAttribute(.backgroundColor, range: full)
-        storage.removeAttribute(.notyHidden, range: full)
-        storage.addAttribute(.foregroundColor, value: ink, range: full)
-        storage.addAttribute(.font, value: font, range: full)
-
-        let ns = storage.string as NSString
-        if Settings.markdownStyling {
-            let line = ns.lineRange(for: NSRange(location: min(caret.location, ns.length), length: 0))
-            markdown(storage, ns, full, ink: ink, size: size, revealing: line)
-        }
-
-        // Tasks are styled after Markdown so a completed task still reads as done
-        // even when its line also carries emphasis.
-        ns.enumerateSubstrings(in: full, options: .byLines) { sub, range, _, _ in
-            guard let sub, Tasks.marker(of: sub) == Tasks.done else { return }
-            storage.addAttribute(.strikethroughStyle,
-                                 value: NSUnderlineStyle.single.rawValue, range: range)
-            storage.addAttribute(.foregroundColor,
-                                 value: ink.withAlphaComponent(0.45), range: range)
-        }
-        storage.endEditing()
-        // Hidden glyphs only disappear once the glyph cache is rebuilt.
-        tv.layoutManager?.invalidateGlyphs(forCharacterRange: full, changeInLength: 0,
-                                           actualCharacterRange: nil)
-        tv.layoutManager?.invalidateLayout(forCharacterRange: full, actualCharacterRange: nil)
-        let end = (storage.string as NSString).length
-        tv.setSelectedRange(NSRange(location: min(caret.location, end),
-                                    length: min(caret.length, end - min(caret.location, end))))
-        tv.window?.invalidateCursorRects(for: tv)
+    static func dismantleNSView(_ scroll: NSScrollView, coordinator: Coordinator) {
+        guard let tv = scroll.documentView as? NSTextView else { return }
+        tv.delegate = nil
+        tv.textStorage?.delegate = nil
     }
 
-    /// Inline Markdown. The source stays plain text — markers are dimmed rather
-    /// than hidden, so what you typed is always what is stored.
-    private static func markdown(_ storage: NSTextStorage, _ ns: NSString,
-                                 _ full: NSRange, ink: NSColor, size: CGFloat,
-                                 revealing caretLine: NSRange) {
-        let faint = ink.withAlphaComponent(0.32)
-
-        func each(_ pattern: String, _ opts: NSRegularExpression.Options = [],
-                  _ body: (NSTextCheckingResult) -> Void) {
-            guard let re = try? NSRegularExpression(pattern: pattern, options: opts) else { return }
-            re.enumerateMatches(in: ns as String, range: full) { m, _, _ in
-                if let m { body(m) }
-            }
-        }
-        /// Punctuation is hidden — unless the caret is on that line, where it is
-        /// only dimmed, so the markers can still be seen and edited.
-        func dim(_ r: NSRange) {
-            if NSIntersectionRange(r, caretLine).length > 0 || caretLine.location == r.location {
-                storage.addAttribute(.foregroundColor, value: faint, range: r)
-            } else {
-                storage.addAttribute(.notyHidden, value: true, range: r)
-                storage.addAttribute(.foregroundColor, value: faint, range: r)
-            }
-        }
-
-        // # heading — bigger and bolder, hashes dimmed
-        each("^(#{1,6})[ \\t]+(.+)$", [.anchorsMatchLines]) { m in
-            let level = m.range(at: 1).length
-            let bump = max(1.5, 7 - CGFloat(level) * 1.1)
-            storage.addAttribute(.font, value: heavier(size + bump), range: m.range)
-            dim(m.range(at: 1))
-        }
-        // **bold** and __bold__
-        each("(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1") { m in
-            storage.addAttribute(.font, value: heavier(size), range: m.range(at: 2))
-            dim(NSRange(location: m.range.location, length: 2))
-            dim(NSRange(location: m.range.upperBound - 2, length: 2))
-        }
-        // *italic* and _italic_
-        each("(?<![\\*_])([\\*_])(?=[^\\*_\\s])(.+?)(?<=[^\\*_\\s])\\1(?![\\*_])") { m in
-            storage.addAttribute(.obliqueness, value: 0.2, range: m.range(at: 2))
-            dim(NSRange(location: m.range.location, length: 1))
-            dim(NSRange(location: m.range.upperBound - 1, length: 1))
-        }
-        // `code`
-        each("`([^`\\n]+)`") { m in
-            storage.addAttribute(.font, value: NSFont.monospacedSystemFont(ofSize: size - 0.5,
-                                                                          weight: .regular),
-                                 range: m.range(at: 1))
-            storage.addAttribute(.backgroundColor, value: ink.withAlphaComponent(0.07),
-                                 range: m.range(at: 1))
-            dim(NSRange(location: m.range.location, length: 1))
-            dim(NSRange(location: m.range.upperBound - 1, length: 1))
-        }
-        // ~~struck~~
-        each("~~(?=\\S)(.+?)(?<=\\S)~~") { m in
-            storage.addAttribute(.strikethroughStyle,
-                                 value: NSUnderlineStyle.single.rawValue, range: m.range(at: 1))
-            dim(NSRange(location: m.range.location, length: 2))
-            dim(NSRange(location: m.range.upperBound - 2, length: 2))
-        }
-        // > quote
-        each("^>[ \\t]?(.*)$", [.anchorsMatchLines]) { m in
-            storage.addAttribute(.foregroundColor, value: ink.withAlphaComponent(0.62),
-                                 range: m.range)
-            storage.addAttribute(.obliqueness, value: 0.15, range: m.range(at: 1))
-            dim(NSRange(location: m.range.location, length: 1))
-        }
-        // - bullet
-        each("^[ \\t]*([-*+])[ \\t]+", [.anchorsMatchLines]) { m in
-            storage.addAttribute(.foregroundColor, value: ink.withAlphaComponent(0.5),
-                                 range: m.range(at: 1))
-        }
+    @discardableResult
+    private static func applyStyles(to tv: NSTextView,
+                                    ranges: [NSRange],
+                                    revealing activeLine: NSRange?,
+                                    ink: NSColor,
+                                    size: CGFloat,
+                                    markdownEnabled: Bool) -> [NSRange] {
+        EditorStyleEngine.apply(to: tv,
+                                ranges: ranges,
+                                revealing: activeLine,
+                                ink: ink,
+                                size: size,
+                                markdownEnabled: markdownEnabled,
+                                bodyFont: bodyFont,
+                                isCompletedTask: { Tasks.marker(of: $0) == Tasks.done })
     }
 
-    /// A bolder cut of whatever face the note is set in.
-    private static func heavier(_ size: CGFloat) -> NSFont {
-        let base = bodyFont(size)
-        let bold = NSFontManager.shared.convert(base, toHaveTrait: .boldFontMask)
-        return bold != base ? bold : NSFont.systemFont(ofSize: size, weight: .semibold)
-    }
+    final class Coordinator: NSObject, NSTextViewDelegate, NSTextStorageDelegate {
+        var parent: NoteTextView
 
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        let parent: NoteTextView
+        private var edits = EditorEditAccumulator()
+        private var lastLine = NSRange(location: NSNotFound, length: 0)
+        private var isApplyingStyles = false
+        private var needsFullPass = false
+        private var appliedInk: NSColor?
+        private var appliedFontName: String?
+        private var appliedFontSize: CGFloat?
+        private var appliedMarkdown: Bool?
+
         init(_ p: NoteTextView) { parent = p }
 
-        private var lastLine = NSRange(location: NSNotFound, length: 0)
+        func attach(to tv: NSTextView) {
+            tv.textStorage?.delegate = self
+            lastLine = activeLine(in: tv)
+            rememberConfiguration()
+        }
+
+        func synchronize(_ tv: NSTextView) {
+            if tv.string != parent.text {
+                // SwiftUI can update around every IME composition event. Never
+                // replace the native string while the input method owns it.
+                guard !tv.hasMarkedText() else {
+                    needsFullPass = true
+                    return
+                }
+                let selection = tv.selectedRange()
+                isApplyingStyles = true
+                tv.string = parent.text
+                edits.clear()
+                tv.setSelectedRange(clamped(selection, to: tv.string.utf16.count))
+                isApplyingStyles = false
+                needsFullPass = true
+            }
+
+            if configurationChanged() { needsFullPass = true }
+            if needsFullPass { applyFullPassIfSafe(to: tv) }
+        }
+
+        func textStorage(_ textStorage: NSTextStorage,
+                         didProcessEditing editedMask: NSTextStorageEditActions,
+                         range editedRange: NSRange,
+                         changeInLength delta: Int) {
+            guard !isApplyingStyles, editedMask.contains(.editedCharacters) else { return }
+            edits.record(editedRange)
+        }
 
         /// Moving the caret to another line changes which markers are revealed.
         func textViewDidChangeSelection(_ notification: Notification) {
-            guard Settings.markdownStyling,
-                  let tv = notification.object as? NSTextView else { return }
-            let ns = tv.string as NSString
-            let caret = min(tv.selectedRange().location, ns.length)
-            let line = ns.lineRange(for: NSRange(location: caret, length: 0))
-            guard line.location != lastLine.location || line.length != lastLine.length else { return }
+            guard !isApplyingStyles,
+                  let tv = notification.object as? NSTextView,
+                  !tv.hasMarkedText() else { return }
+
+            // TextKit can post a selection change while a character edit is
+            // still being finalized. Touching attributes in that intermediate
+            // state can leave the newly generated glyphs absent until a later
+            // edit. Let textDidChange perform the one incremental style pass
+            // after the edit notification has completed.
+            guard !edits.hasPendingEdits else { return }
+
+            let line = activeLine(in: tv)
+            guard parent.markdownEnabled else {
+                lastLine = line
+                return
+            }
+            guard line.location != lastLine.location else { return }
+
+            let previous = lastLine
             lastLine = line
-            NoteTextView.styleTasks(tv, ink: parent.ink, size: parent.fontSize)
+            applyIncremental([previous, line], to: tv, invalidateCursors: false)
         }
 
         func textDidChange(_ notification: Notification) {
-            guard let tv = notification.object as? NSTextView else { return }
-            NoteTextView.styleTasks(tv, ink: parent.ink, size: parent.fontSize)
+            guard !isApplyingStyles,
+                  let tv = notification.object as? NSTextView else { return }
             parent.text = tv.string
+
+            // Binding updates are safe during composition; attributes, layout,
+            // cursor rectangles, and selection writes are deliberately deferred.
+            guard !tv.hasMarkedText() else { return }
+
+            if needsFullPass {
+                applyFullPassIfSafe(to: tv)
+                return
+            }
+            let dirty = consumeEdits(in: tv)
+            if !dirty.isEmpty {
+                applyIncremental(dirty, to: tv, invalidateCursors: true)
+            } else {
+                lastLine = activeLine(in: tv)
+            }
+        }
+
+        private func consumeEdits(in tv: NSTextView) -> [NSRange] {
+            guard let storage = tv.textStorage else { return [] }
+            return edits.consume(in: storage.mutableString, hasMarkedText: tv.hasMarkedText())
+        }
+
+        private func applyIncremental(_ ranges: [NSRange], to tv: NSTextView,
+                                      invalidateCursors: Bool) {
+            guard !tv.hasMarkedText(), !ranges.isEmpty else { return }
+
+            let line = activeLine(in: tv)
+            isApplyingStyles = true
+            NoteTextView.applyStyles(to: tv,
+                                     ranges: ranges,
+                                     revealing: line,
+                                     ink: parent.ink,
+                                     size: parent.fontSize,
+                                     markdownEnabled: parent.markdownEnabled)
+            isApplyingStyles = false
+            lastLine = line
+            if invalidateCursors { tv.window?.invalidateCursorRects(for: tv) }
+        }
+
+        private func applyFullPassIfSafe(to tv: NSTextView) {
+            guard !tv.hasMarkedText(), let storage = tv.textStorage else {
+                needsFullPass = true
+                return
+            }
+
+            let font = NoteTextView.bodyFont(parent.fontSize)
+            let line = activeLine(in: tv)
+            isApplyingStyles = true
+            tv.textColor = parent.ink
+            tv.insertionPointColor = parent.ink
+            tv.font = font
+            NoteTextView.applyStyles(to: tv,
+                                     ranges: [NSRange(location: 0, length: storage.length)],
+                                     revealing: line,
+                                     ink: parent.ink,
+                                     size: parent.fontSize,
+                                     markdownEnabled: parent.markdownEnabled)
+            isApplyingStyles = false
+
+            edits.clear()
+            lastLine = line
+            needsFullPass = false
+            rememberConfiguration()
+            tv.window?.invalidateCursorRects(for: tv)
+        }
+
+        private func activeLine(in tv: NSTextView) -> NSRange {
+            guard let storage = tv.textStorage else {
+                return NSRange(location: 0, length: 0)
+            }
+            return EditorStyleEngine.lineRange(containing: tv.selectedRange().location,
+                                               in: storage.mutableString)
+        }
+
+        private func configurationChanged() -> Bool {
+            guard let appliedInk, let appliedFontName, let appliedFontSize,
+                  let appliedMarkdown else { return true }
+            return !appliedInk.isEqual(parent.ink) ||
+                   appliedFontName != Settings.noteFontName ||
+                   appliedFontSize != parent.fontSize ||
+                   appliedMarkdown != parent.markdownEnabled
+        }
+
+        private func rememberConfiguration() {
+            appliedInk = parent.ink
+            appliedFontName = Settings.noteFontName
+            appliedFontSize = parent.fontSize
+            appliedMarkdown = parent.markdownEnabled
+        }
+
+        private func clamped(_ selection: NSRange, to length: Int) -> NSRange {
+            let location = min(selection.location == NSNotFound ? length : selection.location, length)
+            return NSRange(location: location,
+                           length: min(selection.length, length - location))
         }
 
         /// Return on a task line starts the next task; on an empty one, ends the list.
@@ -477,7 +527,8 @@ struct NoteEditorView: View {
             if deck.findQuery != nil { findBar }
             NoteTextView(text: $text, ink: NSColor(pal.ink),
                          bridge: deck.bridge, autofocus: true,
-                         fontSize: deck.fontSize)
+                         fontSize: deck.fontSize,
+                         markdownEnabled: deck.markdown)
             footer
         }
     }

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -1,0 +1,332 @@
+import AppKit
+import Darwin
+import SwiftUI
+
+@main
+struct EditorStyleEngineTests {
+    private static var failures = 0
+
+    static func main() {
+        testSingleCharacterScope()
+        testNewlineBoundaries()
+        testDistantRangesStayDisjoint()
+        testUTF16Ranges()
+        testMarkedTextAccumulation()
+        testCoordinatorDefersMarkedTextStyling()
+        testCoordinatorStylesOnlyAfterCompletedTextChange()
+        testScopedMarkdownAndTasks()
+        testMarkdownCanBeRemovedIncrementally()
+        testLongNotePlanningStaysLocal()
+
+        guard failures == 0 else {
+            fputs("EditorStyleEngineTests: \(failures) failure(s)\n", stderr)
+            exit(1)
+        }
+        print("EditorStyleEngineTests: all checks passed")
+    }
+
+    private static func check(_ condition: @autoclosure () -> Bool, _ message: String,
+                              file: StaticString = #filePath, line: UInt = #line) {
+        guard !condition() else { return }
+        failures += 1
+        fputs("\(file):\(line): failure: \(message)\n", stderr)
+    }
+
+    private static func testSingleCharacterScope() {
+        let text = "alpha\nbeta gamma\ndelta\n" as NSString
+        let edit = NSRange(location: text.range(of: "gamma").location + 2, length: 1)
+        let ranges = EditorStyleEngine.affectedLineRanges(for: [edit], in: text)
+        let expected = text.lineRange(for: edit)
+        check(ranges == [expected], "a character edit must style only its line")
+    }
+
+    private static func testNewlineBoundaries() {
+        let inserted = "alpha\nbeta" as NSString
+        let insertion = NSRange(location: 5, length: 1)
+        let insertedRanges = EditorStyleEngine.affectedLineRanges(for: [insertion], in: inserted)
+        check(insertedRanges == [NSRange(location: 0, length: inserted.length)],
+              "newline insertion must include both resulting lines")
+
+        let deleted = "alphabeta\nend" as NSString
+        let deletion = NSRange(location: 5, length: 0)
+        let deletedRanges = EditorStyleEngine.affectedLineRanges(for: [deletion], in: deleted)
+        check(deletedRanges == [deleted.lineRange(for: deletion)],
+              "newline deletion must include the merged line")
+    }
+
+    private static func testDistantRangesStayDisjoint() {
+        let text = "first\nsecond\nthird\nfourth\n" as NSString
+        let first = NSRange(location: text.range(of: "first").location + 2, length: 1)
+        let fourth = NSRange(location: text.range(of: "fourth").location + 2, length: 1)
+        let ranges = EditorStyleEngine.affectedLineRanges(for: [first, fourth], in: text)
+        check(ranges.count == 2, "distant edited lines must not absorb untouched lines")
+        check(NSMaxRange(ranges[0]) <= ranges[1].location,
+              "distant planned ranges must remain ordered and disjoint")
+    }
+
+    private static func testUTF16Ranges() {
+        let text = "😀 emoji\n中文输入\nlast" as NSString
+        let cjk = text.range(of: "输")
+        let ranges = EditorStyleEngine.affectedLineRanges(for: [cjk], in: text)
+        check(ranges.count == 1, "CJK edit must produce one line range")
+        check(ranges.allSatisfy { $0.location >= 0 && NSMaxRange($0) <= text.length },
+              "emoji/CJK ranges must stay inside UTF-16 storage bounds")
+        check(EditorStyleEngine.lineRange(containing: Int.max, in: text).location <= text.length,
+              "out-of-bounds caret locations must clamp to EOF")
+    }
+
+    private static func testMarkedTextAccumulation() {
+        let text = "compose 中文 here" as NSString
+        var edits = EditorEditAccumulator()
+        edits.record(NSRange(location: 8, length: 1))
+        check(edits.consume(in: text, hasMarkedText: true).isEmpty,
+              "marked text must not release style ranges")
+        check(edits.hasPendingEdits, "marked text must retain its dirty range")
+        edits.record(NSRange(location: 8, length: 2))
+        let committed = edits.consume(in: text, hasMarkedText: false)
+        check(!committed.isEmpty, "composition commit must release accumulated ranges")
+        check(!edits.hasPendingEdits, "composition commit must clear accumulated ranges")
+    }
+
+    private final class TextBox {
+        var value: String
+        init(_ value: String) { self.value = value }
+    }
+
+    private static func testCoordinatorDefersMarkedTextStyling() {
+        _ = NSApplication.shared
+        let box = TextBox("prefix ")
+        let binding = Binding<String>(get: { box.value }, set: { box.value = $0 })
+        let parent = NoteTextView(text: binding,
+                                  ink: .textColor,
+                                  bridge: EditorBridge(),
+                                  autofocus: false,
+                                  fontSize: 13.5,
+                                  markdownEnabled: true)
+        let coordinator = NoteTextView.Coordinator(parent)
+        let tv = makeTaskTextView(box.value)
+        tv.delegate = coordinator
+        coordinator.attach(to: tv)
+        tv.setSelectedRange(NSRange(location: tv.string.utf16.count, length: 0))
+
+        tv.setMarkedText("zhongwen",
+                         selectedRange: NSRange(location: 8, length: 0),
+                         replacementRange: NSRange(location: NSNotFound, length: 0))
+        check(tv.hasMarkedText(), "AppKit test setup must create a marked range")
+        let marked = tv.markedRange()
+        check(marked.location != NSNotFound && marked.length > 0,
+              "marked-text setup must expose a valid UTF-16 range")
+        guard marked.location != NSNotFound, marked.length > 0,
+              let storage = tv.textStorage else { return }
+
+        storage.addAttribute(.notyHidden, value: true, range: marked)
+        let compositionSelection = tv.selectedRange()
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: tv))
+        check(tv.hasMarkedText(), "coordinator must not commit an active composition")
+        check(tv.markedRange() == marked, "coordinator must not move the marked range")
+        check(tv.selectedRange() == compositionSelection,
+              "coordinator must not move selection during composition")
+        check(storage.attribute(.notyHidden, at: marked.location,
+                                effectiveRange: nil) != nil,
+              "coordinator must not run styling while marked text exists")
+
+        tv.unmarkText()
+        let committedSelection = tv.selectedRange()
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: tv))
+        check(!tv.hasMarkedText(), "composition must be committed before deferred styling")
+        check(tv.selectedRange() == committedSelection,
+              "deferred styling must preserve the committed caret")
+        check(storage.attribute(.notyHidden, at: marked.location,
+                                effectiveRange: nil) == nil,
+              "composition commit must process the accumulated dirty range")
+        check(box.value == tv.string, "committed marked text must reach the SwiftUI binding")
+    }
+
+    private static func testCoordinatorStylesOnlyAfterCompletedTextChange() {
+        _ = NSApplication.shared
+        let box = TextBox("")
+        let binding = Binding<String>(get: { box.value }, set: { box.value = $0 })
+        let parent = NoteTextView(text: binding,
+                                  ink: .textColor,
+                                  bridge: EditorBridge(),
+                                  autofocus: false,
+                                  fontSize: 13.5,
+                                  markdownEnabled: true)
+        let coordinator = NoteTextView.Coordinator(parent)
+        let tv = makeTaskTextView("")
+        tv.delegate = coordinator
+        coordinator.attach(to: tv)
+        guard let storage = tv.textStorage else {
+            check(false, "test text view must have text storage")
+            return
+        }
+
+        let firstInput = "测试"
+        let inserted = NSRange(location: 0, length: (firstInput as NSString).length)
+        storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: firstInput)
+        storage.addAttribute(.notyHidden, value: true, range: inserted)
+        tv.setSelectedRange(NSRange(location: inserted.length, length: 0))
+
+        coordinator.textViewDidChangeSelection(
+            Notification(name: NSTextView.didChangeSelectionNotification, object: tv))
+        check(storage.attribute(.notyHidden, at: 0, effectiveRange: nil) != nil,
+              "selection changes during an edit must not style the unfinished TextKit state")
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: tv))
+        check(storage.attribute(.notyHidden, at: 0, effectiveRange: nil) == nil,
+              "the completed text-change notification must reveal first-line input")
+        check(box.value == firstInput, "first-line input must reach the SwiftUI binding")
+        check(Note.derivedTitle(from: box.value) == firstInput,
+              "visible first-line input and the derived title must use the same source")
+
+        for token in ["\n", "第", "二", "行", "\n", "第", "三", "行"] {
+            let end = storage.length
+            storage.replaceCharacters(in: NSRange(location: end, length: 0), with: token)
+            tv.setSelectedRange(NSRange(location: storage.length, length: 0))
+            coordinator.textViewDidChangeSelection(
+                Notification(name: NSTextView.didChangeSelectionNotification, object: tv))
+            coordinator.textDidChange(
+                Notification(name: NSText.didChangeNotification, object: tv))
+        }
+        check(box.value == "测试\n第二行\n第三行",
+              "rapid early-line edits must all reach the SwiftUI binding")
+
+        guard let layout = tv.layoutManager, let container = tv.textContainer else {
+            check(false, "test text view must have a TextKit layout stack")
+            return
+        }
+        layout.ensureLayout(for: container)
+        let visibleCharacters = NSRange(location: 0, length: storage.length)
+        let glyphs = layout.glyphRange(forCharacterRange: visibleCharacters,
+                                       actualCharacterRange: nil)
+        check(glyphs.length >= 8, "the first three lines must all generate glyphs")
+        for index in glyphs.location..<NSMaxRange(glyphs) {
+            check(!layout.propertyForGlyph(at: index).contains(.null),
+                  "early-line input glyphs must not retain the hidden-marker property")
+        }
+    }
+
+    private static func testScopedMarkdownAndTasks() {
+        let source = "plain\n# Heading\n**bold** *italic* `code` ~~gone~~\n> quote\n- bullet\n☑ done\noutside"
+        let text = source as NSString
+        let tv = makeTextView(source)
+        guard let storage = tv.textStorage else {
+            check(false, "test text view must have text storage")
+            return
+        }
+
+        let styledStart = text.range(of: "# Heading").location
+        let taskLine = text.lineRange(for: text.range(of: "☑ done"))
+        let styled = NSRange(location: styledStart, length: NSMaxRange(taskLine) - styledStart)
+        let outside = text.range(of: "outside")
+        storage.addAttribute(.backgroundColor, value: NSColor.systemRed, range: outside)
+        let selection = NSRange(location: text.range(of: "bold").location + 2, length: 0)
+        tv.setSelectedRange(selection)
+
+        let active = text.lineRange(for: text.range(of: "plain"))
+        let original = tv.string
+        let applied = apply(to: tv, ranges: [styled], revealing: active, markdown: true)
+
+        check(applied == [styled], "style engine must report the scoped range it applied")
+        check(tv.string == original, "styling must not mutate plain-text source")
+        check(tv.selectedRange() == selection, "styling must not rewrite selection")
+        check((storage.attribute(.backgroundColor, at: outside.location,
+                                 effectiveRange: nil) as? NSColor) == NSColor.systemRed,
+              "styling must not alter attributes outside its range")
+
+        let heading = text.range(of: "Heading")
+        let headingFont = storage.attribute(.font, at: heading.location,
+                                            effectiveRange: nil) as? NSFont
+        check((headingFont?.pointSize ?? 0) > 13.5, "heading must retain its larger font")
+
+        let bold = text.range(of: "bold")
+        let boldFont = storage.attribute(.font, at: bold.location,
+                                         effectiveRange: nil) as? NSFont
+        check(boldFont?.fontDescriptor.symbolicTraits.contains(.bold) == true,
+              "bold Markdown must retain a bold font")
+
+        let italic = text.range(of: "italic")
+        check(storage.attribute(.obliqueness, at: italic.location,
+                                effectiveRange: nil) != nil,
+              "italic Markdown must retain obliqueness")
+
+        let code = text.range(of: "code")
+        check(storage.attribute(.backgroundColor, at: code.location,
+                                effectiveRange: nil) != nil,
+              "code Markdown must retain its background")
+
+        let gone = text.range(of: "gone")
+        check(storage.attribute(.strikethroughStyle, at: gone.location,
+                                effectiveRange: nil) != nil,
+              "strikethrough Markdown must retain its decoration")
+        check(storage.attribute(.strikethroughStyle, at: taskLine.location,
+                                effectiveRange: nil) != nil,
+              "completed tasks must remain struck through")
+
+        let openingBoldMarker = text.range(of: "**bold").location
+        check(storage.attribute(.notyHidden, at: openingBoldMarker,
+                                effectiveRange: nil) != nil,
+              "Markdown markers outside the caret line must stay hidden")
+    }
+
+    private static func testMarkdownCanBeRemovedIncrementally() {
+        let source = "**bold**\nplain"
+        let text = source as NSString
+        let tv = makeTextView(source)
+        let line = text.lineRange(for: text.range(of: "bold"))
+        _ = apply(to: tv, ranges: [line], revealing: nil, markdown: true)
+        check(tv.textStorage?.attribute(.notyHidden, at: 0, effectiveRange: nil) != nil,
+              "setup must add hidden Markdown markers")
+        _ = apply(to: tv, ranges: [line], revealing: nil, markdown: false)
+        check(tv.textStorage?.attribute(.notyHidden, at: 0, effectiveRange: nil) == nil,
+              "turning Markdown off must remove hidden markers in the styled range")
+    }
+
+    private static func testLongNotePlanningStaysLocal() {
+        let line = "a moderately long line of note text\n"
+        let source = String(repeating: line, count: 20_000)
+        let text = source as NSString
+        let edit = NSRange(location: text.length / 2, length: 1)
+        let ranges = EditorStyleEngine.affectedLineRanges(for: [edit], in: text)
+        let processed = ranges.reduce(0) { $0 + $1.length }
+        check(processed <= line.utf16.count * 2,
+              "single-character work in a long note must stay paragraph-local")
+        check(processed * 1_000 < text.length,
+              "long-note planning must not approach full-document work")
+    }
+
+    private static func makeTextView(_ source: String) -> NSTextView {
+        let storage = NSTextStorage(string: source)
+        let layout = NSLayoutManager()
+        let container = NSTextContainer(
+            size: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        layout.addTextContainer(container)
+        storage.addLayoutManager(layout)
+        return NSTextView(frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+                          textContainer: container)
+    }
+
+    private static func makeTaskTextView(_ source: String) -> TaskTextView {
+        let storage = NSTextStorage(string: source)
+        let layout = HidingLayoutManager()
+        let container = NSTextContainer(
+            size: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        layout.addTextContainer(container)
+        storage.addLayoutManager(layout)
+        return TaskTextView(frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+                            textContainer: container)
+    }
+
+    @discardableResult
+    private static func apply(to tv: NSTextView, ranges: [NSRange],
+                              revealing active: NSRange?, markdown: Bool) -> [NSRange] {
+        EditorStyleEngine.apply(to: tv,
+                                ranges: ranges,
+                                revealing: active,
+                                ink: .textColor,
+                                size: 13.5,
+                                markdownEnabled: markdown,
+                                bodyFont: { NSFont.systemFont(ofSize: $0) },
+                                isCompletedTask: { $0.first == "☑" })
+    }
+}

--- a/docs/superpowers/specs/2026-08-31-editor-input-performance-design.md
+++ b/docs/superpowers/specs/2026-08-31-editor-input-performance-design.md
@@ -1,0 +1,232 @@
+# Editor Input Performance and Caret Stability Design
+
+Date: 2026-08-31
+
+## Problem
+
+Typing in the main note editor is visibly sluggish and the caret can appear to
+move away from the insertion point. The regression is concentrated in
+`NoteTextView` and was introduced with live Markdown styling:
+
+- Every `textDidChange` call clears and reapplies attributes across the entire
+  document.
+- All Markdown regular expressions scan the entire document on every edit.
+- The complete glyph cache and layout are invalidated after every edit.
+- The selection is explicitly written back after every style pass.
+- Cursor-rectangle rebuilding enumerates every line in the document.
+- The same work can run while an input method owns marked text.
+
+The cost therefore grows with total note length rather than with the text being
+edited. Rewriting selection and layout during marked-text composition also
+interferes with AppKit's caret and candidate-window bookkeeping.
+
+## Goals
+
+1. Keep direct typing responsive in short and long notes.
+2. Keep the logical selection and visible caret stable during ordinary typing,
+   selection movement, undo/redo, paste, and Chinese IME composition.
+3. Preserve current behavior: live Markdown, hidden markers outside the active
+   line, task checkboxes, task Return handling, find, configurable fonts and
+   colours, and 250 ms autosave.
+4. Apply the improvement to both the edge note editor and the Library editor,
+   which share `NoteTextView`.
+5. Make edit-time work proportional to the affected paragraphs. A multi-line
+   paste may cost proportionally to the pasted range, but a one-character edit
+   must not scan or relayout the full note.
+
+## Non-goals
+
+- Changing Markdown syntax or rendering.
+- Replacing TextKit 1 or the hidden-glyph mechanism.
+- Redesigning persistence, encryption, or the note UI.
+- Adding background parsing; AppKit text storage and layout remain main-thread
+  objects.
+
+## Approaches considered
+
+### 1. Debounce the existing full-document restyle
+
+This is the smallest change and removes repeated work during a burst of typing.
+It still produces a full-document pause when the debounce fires, delays visible
+formatting, and can still disturb the caret. It does not meet the stability goal.
+
+### 2. Incremental paragraph styling with IME protection — selected
+
+Capture the actual character edit, expand it to the affected complete
+paragraphs, and update attributes and layout only in that range. Defer all style
+work while `NSTextView` has marked text. This preserves the existing live
+editing model while removing the two root causes: document-wide work and
+selection writes during input.
+
+### 3. Disable Markdown styling while the editor is focused
+
+This provides a fast plain-text editing path but changes the product behavior
+and makes formatting jump on focus changes. It is unnecessary once styling is
+incremental.
+
+## Design
+
+### 1. Separate styling from event coordination
+
+Extract the attribute and Markdown work into a focused `EditorStyleEngine`.
+The engine will:
+
+- own precompiled regular expressions rather than compiling seven expressions
+  per keystroke;
+- clamp and expand character edits to safe complete-line ranges, including the
+  adjacent character needed to handle newline insertion and deletion;
+- reset and apply base, Markdown, and completed-task attributes only inside the
+  requested range;
+- reveal Markdown markers only on the supplied active line;
+- invalidate glyphs and layout only for the range whose attributes changed;
+- refresh base `typingAttributes` after a committed incremental pass so the
+  next character cannot inherit a stale heading or code font;
+- never mutate the underlying string or the text view's selection.
+
+A full-document entry point remains for initial setup, external content
+replacement, font changes, colour changes, and the Markdown setting changing.
+Those are configuration transitions, not the normal typing path.
+
+### 2. Make the coordinator own edit transactions
+
+`NoteTextView.Coordinator` will conform to `NSTextStorageDelegate` in addition
+to `NSTextViewDelegate`. It will record only `.editedCharacters` ranges and
+ignore attribute-only edits created by the style engine. Multiple edits are
+kept as a small normalized range set; only overlapping or adjacent ranges are
+merged. This avoids accidentally styling all text between two distant edits.
+
+The coordinator will also be refreshed from each `updateNSView` call instead of
+retaining the first immutable `NoteTextView` value forever. This keeps the
+binding, ink, font size, and configuration current without recreating the native
+editor.
+
+Normal edit flow:
+
+1. TextKit changes characters and reports the edited range.
+2. The coordinator publishes the current plain string through the binding so
+   the existing autosave flow remains intact.
+3. If the view has marked text, the coordinator retains the dirty range and
+   performs no attribute, layout, cursor-rectangle, or selection operation.
+4. When composition commits, the coordinator consumes the accumulated dirty
+   range, expands it to complete affected lines, and applies incremental styles.
+5. The current `selectedRange` is left entirely under AppKit's control.
+
+The coordinator uses a reentrancy guard while applying attributes. This is a
+defence in depth measure in addition to ignoring attribute-only storage edits.
+
+### 3. Handle caret-line marker visibility incrementally
+
+Moving the caret between lines changes which Markdown punctuation is visible.
+The coordinator will remember the previous active line and restyle only the
+previous and new active lines as two independent ranges when they are not
+adjacent. It will skip this work while marked text exists. It will not call
+`setSelectedRange` after a style-only change.
+
+After a character edit, the stored active-line range is recalculated because
+insertions and deletions can shift later locations. All ranges are clamped to
+the current UTF-16 string length before use.
+
+### 4. Restrict custom cursor work to visible text
+
+`TaskTextView.resetCursorRects` currently enumerates every line. It will derive
+the character range intersecting `visibleRect`, expand that range to complete
+lines, and create checkbox cursor rectangles only there. Character edits may
+still invalidate cursor rectangles, but rebuilding them will be bounded by the
+visible viewport rather than total note length.
+
+### 5. Keep external synchronization explicit
+
+`updateNSView` will distinguish native user edits from an actual external
+binding replacement:
+
+- Equal strings require no assignment or restyle.
+- Marked text is never overwritten by a SwiftUI update.
+- A genuine external replacement may assign `tv.string`, clamp the old
+  selection to the new length, and perform one full style pass.
+- Font, ink, or Markdown configuration changes perform one full attribute pass
+  without rewriting selection.
+
+The Markdown-enabled value will be an explicit editor input and part of the
+coordinator's configuration snapshot. This makes a setting transition
+detectable without consulting mutable global state from inside a style pass.
+
+Initialization installs delegates only after the initial string and full style
+pass so setup does not leave a false pending edit.
+
+## Edge cases and failure handling
+
+- Empty strings and zero-length deletion ranges are valid and are clamped
+  before line expansion.
+- Deleting or inserting a newline includes both sides of the boundary so stale
+  line styles cannot survive a merge or split.
+- Multi-line paste, replacement, undo, and redo style every affected line once.
+- Task insertion, checkbox toggling, and task-list Return use the same character
+  edit pipeline; no special full restyle is needed.
+- With Markdown styling disabled, incremental passes still apply base and task
+  attributes but do not create hidden-marker attributes.
+- If an edit range cannot be recovered, the safe fallback is one full style
+  pass after marked text has ended. The fallback still must not set selection.
+- All editor callbacks and styling remain on the main thread, matching AppKit's
+  threading contract.
+
+## Verification
+
+### Automated checks
+
+Add focused tests around the production range and style engine:
+
+- one-character edits expand only to their affected line;
+- newline insertion/deletion and multi-line replacement include every affected
+  line without escaping into unrelated text;
+- scoped styling does not alter characters or attributes outside the requested
+  range;
+- all supported Markdown and completed-task attributes remain correct;
+- empty and UTF-16-heavy content (emoji and CJK) produces valid ranges;
+- a style-only operation leaves an `NSTextView` selection unchanged;
+- marked-text handling accumulates dirty ranges and does not invoke the engine
+  until composition ends.
+
+The repository has no existing test target, so implementation will add
+`Tests/EditorStyleEngineTests.swift` plus `scripts/test-editor.sh`. The script
+will compile a small command-line AppKit assertion harness with the same macOS
+SDK, deployment target, architecture, and Swift language mode as `build.sh`.
+The harness will compile and exercise the production style-engine source rather
+than a copied implementation.
+
+### Build checks
+
+- `./build.sh debug`
+- `./build.sh release`
+
+Both must succeed with the Command Line Tools JDK-independent Swift toolchain.
+
+### Runtime checks
+
+1. Type continuously at the beginning, middle, and end of a long note containing
+   Markdown and tasks. Characters must appear under the caret without visible
+   pauses or horizontal/vertical caret jumps.
+2. Compose and choose Chinese text through an IME. Marked text and the candidate
+   window must remain anchored, and styling must appear after commit.
+3. Move the caret across formatted lines; markers must reveal on the active line
+   and hide on the old line without changing the logical selection.
+4. Exercise paste, undo/redo, task toggle, task Return, find, font/colour changes,
+   and Markdown on/off.
+5. Repeat direct typing in the Library editor.
+
+For a long-note probe, the test harness will ask the production range planner
+for the ranges produced by a single-character edit and assert that their total
+length is limited to the touched paragraphs rather than the full document.
+This structural measurement is the primary performance gate; subjective
+smoothness is a secondary runtime check.
+
+## Acceptance criteria
+
+- The edit-time path contains no full-document regex scan, attribute reset,
+  glyph invalidation, layout invalidation, or cursor-line enumeration for a
+  one-character edit.
+- No normal edit or selection-only style pass calls `setSelectedRange`.
+- No style or layout operation runs while `hasMarkedText()` is true.
+- Existing editor features and autosave behavior remain functional in both
+  editor surfaces.
+- Automated checks, debug build, release build, and the runtime scenarios above
+  pass.

--- a/scripts/test-editor.sh
+++ b/scripts/test-editor.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Focused range, Markdown, task, selection, and IME-defer checks for the native editor.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SDK="$(xcrun --show-sdk-path --sdk macosx)"
+OUT="$(mktemp -d "${TMPDIR:-/tmp}/noty-editor-tests.XXXXXX")"
+trap 'rm -rf "$OUT"' EXIT
+
+APP_SOURCES=()
+for SOURCE_FILE in "$ROOT"/Sources/*.swift; do
+    [ "$(basename "$SOURCE_FILE")" = "Main.swift" ] || APP_SOURCES+=("$SOURCE_FILE")
+done
+
+swiftc -parse-as-library -swift-version 5 \
+    -target arm64-apple-macosx15.0 \
+    -sdk "$SDK" \
+    "${APP_SOURCES[@]}" \
+    "$ROOT/Tests/EditorStyleEngineTests.swift" \
+    -o "$OUT/EditorStyleEngineTests"
+
+"$OUT/EditorStyleEngineTests"


### PR DESCRIPTION
## Summary

- replace full-document restyling on every keystroke with line-scoped incremental styling
- defer attribute and layout work until TextKit completes edits and IME composition, preventing caret jumps and invisible first lines
- limit task cursor-rect generation to visible content and add a focused AppKit regression test harness

## Why

The editor previously rescanned and reapplied attributes across the entire note after every edit. That made long notes increasingly expensive to type in and could disturb the caret. Styling during an intermediate selection-change callback could also leave the first line, or several early lines, without rendered glyphs even though the same text had already updated the note title.

## Implementation

- add an `EditorStyleEngine` that expands edits to complete line ranges, keeps distant changes disjoint, and preserves Markdown/task styling
- accumulate native text-storage edits and defer styling while marked text is active
- perform character-edit styling only after `textDidChange`, then explicitly invalidate scoped glyph, layout, and display ranges
- reserve full-document passes for initial content and explicit appearance/configuration changes
- document the design and expose `./scripts/test-editor.sh` for focused regression checks

## Testing

- `./scripts/test-editor.sh`
- `./build.sh debug`
- `./build.sh release`
- manually verified blank-note title derivation and immediate rendering of the first three lines
- manually verified input in a 65,208-character note and in the library editor


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown styling now follows the app’s Markdown setting in note editors.
  * Editor formatting updates incrementally as you type, helping preserve caret stability and improve performance.
  * Task and Markdown styling remains responsive during text composition.

* **Bug Fixes**
  * Limited editor hit-testing and styling work to relevant or visible text areas.

* **Tests**
  * Added focused regression coverage for editor ranges, styling, input composition, and long documents.
  * Added a documented command for running editor checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->