### PR TITLE
Fix the pill flashing at the top corner when hovering the deck

### DIFF
--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -52,11 +52,6 @@ final class DeckModel: ObservableObject {
     /// and nothing else — recomputing the position from a height that changes
     /// mid-resize makes the note jump the instant the drag ends.
     @Published var openedHeight: CGFloat = Settings.noteSize.height
-    /// Published by the controller the instant the panel is resized. Reading this
-    /// instead of a GeometryReader matters: the reader reports the *previous* size
-    /// for a frame or two after a resize, and the deck lays out against the wrong
-    /// edge in the meantime.
-    @Published var panelHeight: CGFloat = 0
 
     func syncPreferences() {
         style = Settings.deckStyle
@@ -170,7 +165,6 @@ final class DeckController: NSObject {
                            y: vis.minY, width: w, height: vis.height)
         }
         panel.setFrame(frame, display: true, animate: false)
-        if model.panelHeight != frame.height { model.panelHeight = frame.height }
     }
 
     func refreshLevel() {

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -30,10 +30,16 @@ struct DeckRootView: View {
     }
 
     var body: some View {
-        let h = max(1, deck.panelHeight)
-        let lay = layout(h)
+        // The height comes from the live layout pass, not from a value cached on
+        // the model. When the panel resizes, AppKit relays out the existing view
+        // tree at the new size *before* SwiftUI re-evaluates this body; anything
+        // computed from a stored height is stale for that frame, and the pill
+        // drew with zero padding at the top corner of the screen.
+        GeometryReader { geo in
+            let h = max(1, geo.size.height)
+            let lay = layout(h)
 
-        return ZStack(alignment: onRight ? .topTrailing : .topLeading) {
+            ZStack(alignment: onRight ? .topTrailing : .topLeading) {
 
                 if deck.fanVisible {
                     FanColumn(deck: deck, controller: controller,
@@ -42,7 +48,7 @@ struct DeckRootView: View {
                         .padding(.top, fanTop(lay, panelHeight: h))
                 } else {
                     PillView(notes: store.active)
-                        .padding(.top, max(0, (h - DeckGeom.pillHeight(noteCount: max(1, store.active.count))) / 2))
+                        .padding(.top, pillTop(panelHeight: h))
                         .padding(onRight ? .trailing : .leading, 1)
                         .transition(.opacity)
                 }
@@ -57,14 +63,24 @@ struct DeckRootView: View {
                         .id(id)
                 }
             }
-        // A ZStack is only as wide as its widest child, so it has to be told to fill
-        // the panel — otherwise the deck sits at the panel's left edge with a dead
-        // gap against the screen. Filling from the parent's proposal (rather than a
-        // measured width) keeps it pinned to the edge through a resize.
-        .frame(maxWidth: .infinity, maxHeight: .infinity,
-               alignment: onRight ? .topTrailing : .topLeading)
+            // A ZStack is only as wide as its widest child, so it has to be told to fill
+            // the panel — otherwise the deck sits at the panel's left edge with a dead
+            // gap against the screen. Filling from the parent's proposal (rather than a
+            // measured width) keeps it pinned to the edge through a resize.
+            .frame(maxWidth: .infinity, maxHeight: .infinity,
+                   alignment: onRight ? .topTrailing : .topLeading)
+        }
         .animation(.spring(response: 0.30, dampingFraction: 0.9), value: deck.fanVisible)
         .animation(.easeInOut(duration: 0.22), value: deck.style)
+    }
+
+    /// Where the pill sits, for any panel height. At rest the panel is exactly the
+    /// pill's height and this is zero; in a full-height panel it lands on the same
+    /// screen position the resting panel occupies, so the pill does not move as the
+    /// panel grows around it or shrinks back to it.
+    private func pillTop(panelHeight h: CGFloat) -> CGFloat {
+        let pillH = DeckGeom.pillHeight(noteCount: max(1, store.active.count))
+        return (1.0 - Settings.deckYRatio) * max(0, h - pillH)
     }
 
     private func fanTop(_ lay: DeckLayout, panelHeight h: CGFloat) -> CGFloat {


### PR DESCRIPTION
Fixes #11.

## What you see

Hover the pill on the right edge: the colour dots jump to the top-right corner of the screen for a frame, fade out there, and then the tabs fan out. The same flicker happens in reverse when the deck folds back into the pill.

## Root cause

`DeckController.layout(for:)` grows the panel from pill-height to full screen height with `panel.setFrame(frame, display: true)`. `display: true` makes AppKit lay out the **existing** SwiftUI tree at the new size immediately — before SwiftUI has re-evaluated `DeckRootView.body` for the state change that follows.

That body computed every position from `deck.panelHeight`, a value the controller published after the resize. For that one forced layout pass it was still the old pill height (47), so the pill's `.padding(.top, (h - pillH) / 2)` was `0`, and the ZStack's `.topTrailing` alignment put it in the corner. The next SwiftUI pass then swaps in the fan, and the pill's `.transition(.opacity)` fades it out from where it already was: the corner.

Probes (`DeckLog` inside the body and inside a `GeometryReader` in the layout pass) confirmed the order:

```
setState rest -> fan  panel=14x47
PROBE layout size=482x1073      <- existing tree relaid out at full height (stale body, pill padding 0)
PROBE body h=1073 state=fan     <- body catches up one pass later
```

and on collapse the shrink pass relaid the full-height body into a 47 pt panel, pushing the pill below it (`layout size=14x560` before `14x47`).

## Fix

- `DeckRootView.body` is wrapped in a `GeometryReader` and takes the height from `geo.size.height`. The reader's closure runs *in* the layout pass, so the forced relayout computes with the real size instead of a cached one. (The old comment on `panelHeight` said a GeometryReader lags by a frame or two — that is true of a size read back through `onChange`/preferences into state, but not of a value used inline in the reader's closure; the probes above show it receiving the new size on the very first pass.)
- New `pillTop(panelHeight:)` places the pill at `(1 - deckYRatio) * (h - pillH)`. In the resting panel `h == pillH`, so it is `0` as before; in the full-height panel it resolves to the exact screen position the resting panel occupies. The pill therefore does not move while the panel grows around it or shrinks back to it — it only cross-fades with the tabs, in place.
- `DeckModel.panelHeight` and the line that fed it are removed; nothing reads them anymore.

Width alignment is unchanged (`.frame(maxWidth: .infinity, alignment: .topTrailing)` from the parent's proposal), so the expanded-note transition and its two-frame delay in `setState` are untouched.

## Verification

Debug build, `NOTY_DEBUG_DECK=1`, pointer driven with synthetic `CGEvent`s (1710×1107 display, `deckYRatio` 0.5, 47 pt pill):

```
setState rest -> fan  panel=14x47
PROBE layout size=482x1073 pillTop=513   <- 1073 - 513 - 47 = 513 = resting panel's y
...
setState fan -> rest  panel=482x1073
shrink fires; state=rest
PROBE layout size=14x47   pillTop=0
```

Same screen position in both directions. Full cycle rest → fan → expanded → rest exercised; `./scripts/test-editor.sh` passes. Probes removed before committing.

To check by hand: `./build.sh debug run`, hover the pill, watch the dots — they should now stay put and fade into the tabs. Leave the deck and they fade back in at the same spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
