### PR TITLE
fix: prevent note position jumping and flickering while typing

### DIFF
--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -52,6 +52,9 @@ final class DeckModel: ObservableObject {
     /// and nothing else — recomputing the position from a height that changes
     /// mid-resize makes the note jump the instant the drag ends.
     @Published var openedHeight: CGFloat = Settings.noteSize.height
+    /// The note's top offset at the moment it opened. Anchored so title edits
+    /// and autosaves while typing never make the open note jump or flicker.
+    @Published var openedTop: CGFloat?
     /// Published by the controller the instant the panel is resized. Reading this
     /// instead of a GeometryReader matters: the reader reports the *previous* size
     /// for a frame or two after a resize, and the deck lays out against the wrong
@@ -388,6 +391,7 @@ final class DeckController: NSObject {
     func expand(_ id: String) {
         noteActivity()
         model.openedHeight = Settings.noteSize.height
+        model.openedTop = nil
         manager?.deckDidActivate(self)
         setState(.expanded(id))
         NSApp.activate()
@@ -397,6 +401,7 @@ final class DeckController: NSObject {
     /// Closing a note steps back to the deck — the tabs stay where they were.
     /// Only leaving the deck entirely puts it back to sleep.
     func collapse() {
+        model.openedTop = nil
         if model.state.expandedID != nil {
             setState(.fan)
             NSApp.deactivate()

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -77,6 +77,7 @@ struct DeckRootView: View {
 
     /// Keep the open note level with its own tab, without letting it run off-screen.
     private func editorTop(_ lay: DeckLayout, id: String) -> CGFloat {
+        if let top = deck.openedTop { return top }
         let idx = visible.firstIndex { $0.id == id } ?? 0
         let h = deck.openedHeight
         let fTop = fanTop(lay, panelHeight: lay.panelHeight)
@@ -84,7 +85,9 @@ struct DeckRootView: View {
         let stripCenter = fTop + CGFloat(idx) * lay.pitch + strip / 2
         let ideal = stripCenter - h / 2
         let lowest = max(10, lay.panelHeight - h - 10)
-        return min(max(10, ideal), lowest)
+        let resolved = min(max(10, ideal), lowest)
+        DispatchQueue.main.async { deck.openedTop = resolved }
+        return resolved
     }
 }
 


### PR DESCRIPTION
### Summary
  Fixes an issue where editing a note (particularly the first line/title or
  continuous typing) triggers autosave and causes the expanded note card to jump
  vertically and flicker on screen.

  ### Changes
  - Added `@Published var openedTop: CGFloat?` in `DeckModel` to anchor the
  note's vertical offset upon opening.
  - Updated `DeckViews.swift` (`editorTop`) to respect the anchored `openedTop`
  during an active editing session.
  - Reset `openedTop` back to `nil` on note collapse/expand transitions in
  `DeckController.swift`.

  ### Related Issue
  Fixes #14 