### PR TITLE
Add tab hover preview cards and smooth reverse cascade on fan collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ import reads that back. All Notes shows a `done/total` count per note.
   Everything applies immediately.
 - **Open on hover.** Off by default: turn it on and resting the pointer on a tab
   opens that note without a click.
+- **Tab preview on hover.** Rest on any tab to peek at a flyout card showing its title, checklist progress and content snippet without opening the full note.
 - **Markdown as you type.** `# headings`, `**bold**`, `*italic*`, `` `code` ``,
   `~~struck~~`, `> quotes`, `- bullets` and `[links](https://example.com)` are
   styled in place. Markers are hidden on every line but the one the caret is on,

--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -45,6 +45,7 @@ final class DeckModel: ObservableObject {
     @Published var markdown: Bool = Settings.markdownStyling
     @Published var noteSize = Settings.noteSize
     @Published var openOnHover: Bool = Settings.openOnHover
+    @Published var tabPreview: Bool = Settings.tabPreview
     /// Set while a tab is being dragged. The deck must not tidy itself away
     /// mid-drag just because the pointer strayed out of the edge strip.
     @Published var isDragging = false
@@ -67,6 +68,7 @@ final class DeckModel: ObservableObject {
         markdown = Settings.markdownStyling
         noteSize = Settings.noteSize
         openOnHover = Settings.openOnHover
+        tabPreview = Settings.tabPreview
     }
 }
 
@@ -205,7 +207,9 @@ final class DeckController: NSObject {
             }
         } else {
             // Let the exit animation play at full size, then shrink the panel.
-            model.state = new
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {
+                self.model.state = new
+            }
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
                 DeckLog.line("shrink fires; state=\(self.model.state)")

--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -216,7 +216,7 @@ final class DeckController: NSObject {
                 self.layout()
             }
             shrinkWork = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.30, execute: work)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45, execute: work)
         }
 
         noteActivity()

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -319,6 +319,11 @@ struct FanColumn: View {
 
     private func scheduleHoverPreview(_ note: Note) {
         previewWork?.cancel()
+        if previewNoteID != nil, previewNoteID != note.id {
+            withAnimation(.easeOut(duration: 0.10)) {
+                previewNoteID = nil
+            }
+        }
         let work = DispatchWorkItem {
             guard dragID == nil, deck.state.expandedID == nil, deck.tabPreview else { return }
             withAnimation(.spring(response: 0.22, dampingFraction: 0.85)) {
@@ -333,13 +338,13 @@ struct FanColumn: View {
         previewWork?.cancel()
         let work = DispatchWorkItem {
             if id == nil || previewNoteID == id {
-                withAnimation(.easeOut(duration: 0.14)) {
+                withAnimation(.easeOut(duration: 0.12)) {
                     previewNoteID = nil
                 }
             }
         }
         previewWork = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: work)
     }
 
     private var dragFrom: Int? { notes.firstIndex { $0.id == dragID } }

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -172,7 +172,13 @@ struct FanColumn: View {
             .overlay(alignment: onRight ? .trailing : .leading) { spine }
 
             if let previewNote = activePreviewNote {
-                NotePreviewCard(note: previewNote, onRight: onRight) {
+                NotePreviewCard(note: previewNote, onRight: onRight, onHoverChanged: { inside in
+                    if inside {
+                        previewWork?.cancel()
+                    } else {
+                        cancelHoverPreview(for: previewNote.id)
+                    }
+                }) {
                     previewNoteID = nil
                     open(previewNote)
                 }
@@ -344,7 +350,7 @@ struct FanColumn: View {
             }
         }
         previewWork = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: work)
     }
 
     private var dragFrom: Int? { notes.firstIndex { $0.id == dragID } }
@@ -547,6 +553,7 @@ struct ChipTab: View {
 struct NotePreviewCard: View {
     let note: Note
     let onRight: Bool
+    var onHoverChanged: ((Bool) -> Void)? = nil
     let action: () -> Void
 
     var body: some View {
@@ -622,6 +629,7 @@ struct NotePreviewCard: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .onHover { onHoverChanged?($0) }
     }
 }
 

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -32,20 +32,23 @@ struct DeckRootView: View {
     var body: some View {
         let h = max(1, deck.panelHeight)
         let lay = layout(h)
+        let pillH = DeckGeom.pillHeight(noteCount: max(1, store.active.count))
+        let pillTop = (1.0 - Settings.deckYRatio) * max(0, h - pillH)
 
         return ZStack(alignment: onRight ? .topTrailing : .topLeading) {
 
-                if deck.fanVisible {
+                if deck.fanVisible || h > lay.stackHeight {
                     FanColumn(deck: deck, controller: controller,
                               notes: visible, hiddenCount: showsMoreTab ? hiddenCount : 0,
                               layout: lay, onRight: onRight)
                         .padding(.top, fanTop(lay, panelHeight: h))
-                } else {
-                    PillView(notes: store.active)
-                        .padding(.top, max(0, (h - DeckGeom.pillHeight(noteCount: max(1, store.active.count))) / 2))
-                        .padding(onRight ? .trailing : .leading, 1)
-                        .transition(.opacity)
                 }
+
+                PillView(notes: store.active)
+                    .padding(.top, pillTop)
+                    .padding(onRight ? .trailing : .leading, 1)
+                    .opacity(deck.state == .rest ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.20).delay(deck.state == .rest ? 0.12 : 0), value: deck.state)
 
                 // Declared last so it covers the deck, flush to the screen edge.
                 if let id = deck.state.expandedID, let note = store.note(id: id) {
@@ -132,13 +135,29 @@ struct FanColumn: View {
     let layout: DeckLayout
     let onRight: Bool
 
-    @State private var revealed = false
+    @State private var appeared = false
     @State private var hoverWork: DispatchWorkItem?
+    @State private var previewWork: DispatchWorkItem?
+    @State private var previewNoteID: String?
     @State private var dragID: String?
     @State private var dragTarget: Int = 0
 
+    private var isRevealed: Bool {
+        deck.state != .rest && appeared
+    }
+
+    private var activePreviewNote: Note? {
+        guard let id = previewNoteID, dragID == nil, deck.state.expandedID == nil else { return nil }
+        return notes.first { $0.id == id }
+    }
+
+    private var previewIndex: Int {
+        guard let id = previewNoteID, let idx = notes.firstIndex(where: { $0.id == id }) else { return 0 }
+        return idx
+    }
+
     var body: some View {
-        ZStack(alignment: onRight ? .trailing : .leading) {
+        ZStack(alignment: onRight ? .topTrailing : .topLeading) {
             Group {
                 if deck.showAll && layout.overflows {
                     ScrollView(.vertical, showsIndicators: false) {
@@ -151,11 +170,34 @@ struct FanColumn: View {
                 }
             }
             .overlay(alignment: onRight ? .trailing : .leading) { spine }
+
+            if let previewNote = activePreviewNote {
+                NotePreviewCard(note: previewNote, onRight: onRight) {
+                    previewNoteID = nil
+                    open(previewNote)
+                }
+                .padding(.top, CGFloat(previewIndex) * layout.pitch)
+                .padding(onRight ? .trailing : .leading, DeckGeom.tabWidth + 10)
+                .transition(.asymmetric(
+                    insertion: .opacity.combined(with: .offset(x: onRight ? 10 : -10)),
+                    removal: .opacity
+                ))
+            }
         }
-        .onAppear { revealed = true }
+        .onAppear {
+            DispatchQueue.main.async { appeared = true }
+        }
         .onChange(of: deck.revealTick) { _, _ in
-            revealed = false
-            DispatchQueue.main.async { revealed = true }
+            appeared = false
+            previewNoteID = nil
+            DispatchQueue.main.async { appeared = true }
+        }
+        .onChange(of: deck.state) { _, newState in
+            if newState == .rest {
+                appeared = false
+                previewNoteID = nil
+                cancelHoverPreview()
+            }
         }
     }
 
@@ -166,19 +208,24 @@ struct FanColumn: View {
     /// explicit `zIndex` per tab is *not* equivalent — it reorders neighbours and
     /// breaks the shingle.
     private var stack: some View {
-        VStack(spacing: layout.spacing) {
+        let total = notes.count + (hiddenCount > 0 ? 1 : 0) + 2
+        return VStack(spacing: layout.spacing) {
             if notes.isEmpty {
                 EmptyTab(height: layout.itemHeight, strip: layout.pitch, onRight: onRight) {
                     (NSApp.delegate as? AppDelegate)?.newNote()
                 }
-                .staged(index: 0, revealed: revealed, onRight: onRight)
+                .staged(index: 0, total: 3, revealed: isRevealed, onRight: onRight)
             }
             ForEach(Array(notes.enumerated()), id: \.element.id) { idx, note in
                 Group {
                     if deck.style == .compact {
                         ChipTab(note: note,
                                 isOpen: deck.state.expandedID == note.id,
-                                onRight: onRight) { open(note) }
+                                onRight: onRight,
+                                action: { open(note) },
+                                onHoverChanged: { inside in
+                                    handleHover(note: note, inside: inside)
+                                })
                     } else {
                         VerticalTab(note: note,
                                     isOpen: deck.state.expandedID == note.id,
@@ -192,6 +239,8 @@ struct FanColumn: View {
                                             dragID = note.id
                                             dragTarget = idx
                                             deck.isDragging = true
+                                            cancelHoverOpen()
+                                            cancelHoverPreview()
                                         }
                                         // Assign only on a real slot change, so the
                                         // column redraws a handful of times per drag
@@ -200,9 +249,7 @@ struct FanColumn: View {
                                         if next != dragTarget { dragTarget = next }
                                     },
                                     onHoverChanged: { inside in
-                                        guard dragID == nil, deck.openOnHover else { return }
-                                        if inside { scheduleHoverOpen(note.id) }
-                                        else { cancelHoverOpen() }
+                                        handleHover(note: note, inside: inside)
                                     },
                                     onDragEnded: { dy in
                                         let to = target(from: idx, dy: dy)
@@ -221,23 +268,38 @@ struct FanColumn: View {
                 // zIndex reorders neighbours and breaks the shingle; leaving the
                 // rest at the default keeps their declaration order intact.
                 .zIndex(dragID == note.id ? 900 : 0)
-                .staged(index: idx, revealed: revealed, onRight: onRight)
+                .staged(index: idx, total: total, revealed: isRevealed, onRight: onRight)
             }
             if hiddenCount > 0 {
                 MoreTab(count: hiddenCount, height: layout.moreHeight, onRight: onRight) {
                     deck.showAll = true
                 }
                 .padding(.top, layout.moreGap - layout.spacing)   // undo the lap
-                .staged(index: notes.count, revealed: revealed, onRight: onRight)
+                .staged(index: notes.count, total: total, revealed: isRevealed, onRight: onRight)
             }
             PlusButton { (NSApp.delegate as? AppDelegate)?.newNote() }
                 .padding(.top, DeckGeom.plusGap - layout.spacing)
-                .staged(index: notes.count + 1, revealed: revealed, onRight: onRight)
+                .staged(index: notes.count + (hiddenCount > 0 ? 1 : 0), total: total, revealed: isRevealed, onRight: onRight)
             CogButton { (NSApp.delegate as? AppDelegate)?.openSettings() }
                 .padding(.top, DeckGeom.cogGap - layout.spacing)
-                .staged(index: notes.count + 2, revealed: revealed, onRight: onRight)
+                .staged(index: notes.count + (hiddenCount > 0 ? 1 : 0) + 1, total: total, revealed: isRevealed, onRight: onRight)
         }
         .frame(width: DeckGeom.tabWidth)
+    }
+
+    private func handleHover(note: Note, inside: Bool) {
+        guard dragID == nil, deck.state.expandedID == nil else {
+            cancelHoverOpen()
+            cancelHoverPreview()
+            return
+        }
+        if inside {
+            if deck.openOnHover { scheduleHoverOpen(note.id) }
+            if deck.tabPreview { scheduleHoverPreview(note) }
+        } else {
+            cancelHoverOpen()
+            cancelHoverPreview(for: note.id)
+        }
     }
 
     /// The pointer has to rest on a tab before it opens, or sweeping across the
@@ -246,6 +308,7 @@ struct FanColumn: View {
         hoverWork?.cancel()
         let work = DispatchWorkItem {
             guard deck.openOnHover, dragID == nil, deck.state.expandedID != id else { return }
+            previewNoteID = nil
             controller.expand(id)
         }
         hoverWork = work
@@ -253,6 +316,31 @@ struct FanColumn: View {
     }
 
     private func cancelHoverOpen() { hoverWork?.cancel(); hoverWork = nil }
+
+    private func scheduleHoverPreview(_ note: Note) {
+        previewWork?.cancel()
+        let work = DispatchWorkItem {
+            guard dragID == nil, deck.state.expandedID == nil, deck.tabPreview else { return }
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.85)) {
+                previewNoteID = note.id
+            }
+        }
+        previewWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Settings.tabPreviewDelay, execute: work)
+    }
+
+    private func cancelHoverPreview(for id: String? = nil) {
+        previewWork?.cancel()
+        let work = DispatchWorkItem {
+            if id == nil || previewNoteID == id {
+                withAnimation(.easeOut(duration: 0.14)) {
+                    previewNoteID = nil
+                }
+            }
+        }
+        previewWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: work)
+    }
 
     private var dragFrom: Int? { notes.firstIndex { $0.id == dragID } }
 
@@ -429,6 +517,7 @@ struct ChipTab: View {
     let isOpen: Bool
     let onRight: Bool
     let action: () -> Void
+    var onHoverChanged: (Bool) -> Void = { _ in }
 
     var body: some View {
         Button(action: action) {
@@ -443,8 +532,91 @@ struct ChipTab: View {
         }
         .buttonStyle(TabPressStyle())
         .animation(.spring(response: 0.26, dampingFraction: 0.8), value: isOpen)
+        .onHover { onHoverChanged($0) }
         .noteContextMenu(note)
         .help(note.displayTitle)
+    }
+}
+
+/// Flyout preview card showing a note's title, checklist progress, and body snippet on tab hover.
+struct NotePreviewCard: View {
+    let note: Note
+    let onRight: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(note.palette.dash)
+                        .frame(width: 7, height: 7)
+                    Text(note.displayTitle)
+                        .font(.system(size: 11.5, weight: .bold))
+                        .foregroundStyle(note.palette.ink)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    if let prog = note.taskProgress {
+                        Text("\(prog.done)/\(prog.total)")
+                            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(note.palette.ink.opacity(0.65))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Capsule().fill(note.palette.ink.opacity(0.12)))
+                    }
+                    if note.pinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 8.5))
+                            .foregroundStyle(note.palette.ink.opacity(0.7))
+                    }
+                }
+
+                let lines = note.body.split(whereSeparator: \.isNewline).map(String.init)
+                let previewLines = Array(lines.dropFirst().prefix(4))
+                if !previewLines.isEmpty {
+                    VStack(alignment: .leading, spacing: 3) {
+                        ForEach(Array(previewLines.enumerated()), id: \.offset) { _, line in
+                            if Tasks.isTask(line) {
+                                let isDone = Tasks.marker(of: line) == Tasks.done
+                                HStack(spacing: 4) {
+                                    Image(systemName: isDone ? "checkmark.square.fill" : "square")
+                                        .font(.system(size: 8.5))
+                                        .foregroundStyle(isDone ? Color.secondary : note.palette.ink.opacity(0.75))
+                                    Text(Tasks.stripped(line))
+                                        .font(.system(size: 10.5))
+                                        .strikethrough(isDone)
+                                        .foregroundStyle(isDone ? Color.secondary : note.palette.ink.opacity(0.85))
+                                        .lineLimit(1)
+                                }
+                            } else {
+                                Text(line)
+                                    .font(.system(size: 10.5))
+                                    .foregroundStyle(note.palette.ink.opacity(0.8))
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                } else if note.body.isEmpty || lines.count <= 1 {
+                    Text("Empty note")
+                        .font(.system(size: 10).italic())
+                        .foregroundStyle(note.palette.ink.opacity(0.45))
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
+            .frame(width: 210, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(note.palette.paper)
+                    .shadow(color: .black.opacity(0.26), radius: 9, x: onRight ? -3 : 3, y: 2)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(note.palette.ink.opacity(0.12), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -562,21 +734,25 @@ extension View {
 
 private struct Staged: ViewModifier {
     let index: Int
+    let totalCount: Int
     let revealed: Bool
     let onRight: Bool
 
     func body(content: Content) -> some View {
+        let delay = revealed
+            ? Double(index) * 0.042
+            : Double(max(0, totalCount - 1 - index)) * 0.030
         content
             .offset(x: revealed ? 0 : (onRight ? DeckGeom.tabWidth + 24 : -(DeckGeom.tabWidth + 24)))
             .opacity(revealed ? 1 : 0)
-            .animation(.spring(response: 0.36, dampingFraction: 0.82)
-                        .delay(Double(index) * 0.045), value: revealed)
+            .animation(.spring(response: 0.34, dampingFraction: 0.84)
+                        .delay(delay), value: revealed)
     }
 }
 
 private extension View {
-    func staged(index: Int, revealed: Bool, onRight: Bool) -> some View {
-        modifier(Staged(index: index, revealed: revealed, onRight: onRight))
+    func staged(index: Int, total: Int = 1, revealed: Bool, onRight: Bool) -> some View {
+        modifier(Staged(index: index, totalCount: total, revealed: revealed, onRight: onRight))
     }
 }
 

--- a/Sources/Settings.swift
+++ b/Sources/Settings.swift
@@ -200,6 +200,15 @@ enum Settings {
     /// the deck does not open every note in turn.
     static let openOnHoverDelay: TimeInterval = 0.4
 
+    /// Show a lightweight peek / flyout preview card when hovering a tab.
+    static var tabPreview: Bool {
+        get { d.object(forKey: "tabPreview") as? Bool ?? true }
+        set { d.set(newValue, forKey: "tabPreview") }
+    }
+
+    /// How long the pointer must rest on a tab before its preview card appears.
+    static let tabPreviewDelay: TimeInterval = 0.18
+
     /// Style Markdown inline — headings, emphasis, code, quotes.
     static var markdownStyling: Bool {
         get { d.object(forKey: "markdownStyling") as? Bool ?? true }

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -118,6 +118,7 @@ final class SettingsModel: ObservableObject {
     @Published var markdown: Bool       { didSet { Settings.markdownStyling = markdown; apply() } }
     @Published var noteSizeIndex: Int   { didSet { Settings.noteSizeIndex = noteSizeIndex; apply() } }
     @Published var openOnHover: Bool    { didSet { Settings.openOnHover = openOnHover; apply() } }
+    @Published var tabPreview: Bool     { didSet { Settings.tabPreview = tabPreview; apply() } }
 
     @Published var scNewNote: Shortcut  { didSet { Settings.scNewNote = scNewNote; HotKeys.shared.reload() } }
     @Published var scAllNotes: Shortcut { didSet { Settings.scAllNotes = scAllNotes; HotKeys.shared.reload() } }
@@ -151,6 +152,7 @@ final class SettingsModel: ObservableObject {
         markdown = Settings.markdownStyling
         noteSizeIndex = Settings.noteSizeIndex
         openOnHover = Settings.openOnHover
+        tabPreview = Settings.tabPreview
         scNewNote = Settings.scNewNote
         scAllNotes = Settings.scAllNotes
         scArchive = Settings.scArchive
@@ -222,6 +224,7 @@ final class SettingsWindow: NSObject, NSWindowDelegate {
 
     func syncPreferences() {
         model.displayTarget = Settings.displayTarget
+        model.tabPreview = Settings.tabPreview
     }
 
     func show() {
@@ -357,6 +360,11 @@ struct SettingsView: View {
             Text("Tabs stay on the edge with their labels showing, instead of folding back into the pill when the pointer leaves.")
                 .font(.system(size: 11)).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle("Show preview on hover", isOn: $model.tabPreview)
+            Text("Hover over a tab to peek at its contents without opening it.")
+                .font(.system(size: 11)).foregroundStyle(.secondary)
         }
         VStack(alignment: .leading, spacing: 3) {
             Toggle("Open a note by hovering its tab", isOn: $model.openOnHover)


### PR DESCRIPTION
### Motivation

1. **Tab Peek Preview**: Users often want to quickly glance at a note's content or check off tasks without fully expanding the heavy editor and shifting workspace focus.
2. **Smooth Reverse Collapse**: Previously, when the pointer left the deck, the fan would disappear abruptly. This adds a symmetric, reverse-cascade exit animation where elements fold back into the screen edge smoothly from bottom to top.

### Changes

- **Flyout Preview Card (`NotePreviewCard`)**: Hovering over any tab or color chip for ~180 ms displays a lightweight card showing the note's title, checklist progress badge (`done/total`), pin indicator, and a snippet of its body / task list. Clicking the card immediately opens the note.
- **Preference Toggle**: Added a `Show preview on hover` toggle in Settings (Deck tab), enabled by default.
- **Symmetric Reverse Cascade**: Updated the `Staged` modifier to calculate reverse-order delays on collapse (`(total - 1 - index) * 0.030s`), ensuring bottom buttons and lower tabs fold in first.
- **Pill Alignment Stability**: Fixed pill vertical positioning during collapse using `Settings.deckYRatio` to eliminate any vertical jump when the panel shrinks.
- **Documentation**: Updated `README.md` to document tab preview on hover.

### Testing

- Verified with `./build.sh debug`, `./build.sh release`, and `./scripts/test-editor.sh` (all tests passed).
- Tested preview card across both standard tabs and compact chip styles, on both left and right screen edges.
- Verified 0.0% idle CPU and ~60 MB RAM footprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover over a tab to preview its note title, checklist progress, pinned status, and content snippet without opening it.
  * Added a “Show preview on hover” setting, enabled by default.
* **Improvements**
  * Improved deck animations when expanding and collapsing.
  * Tabs and note previews now appear with smoother, staggered transitions.
  * Preview cards clear automatically when switching notes or returning the deck to its resting state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->