### PR TITLE
Add per-note Auto, LTR, and RTL text direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ import reads that back. All Notes shows a `done/total` count per note.
   `⇧↩` for a new line, `esc` to cancel, click away to dismiss.
 - **All Notes** (`⌥⌘A`) — one window, search across every note body and title,
   with an editable detail pane.
+- **Bidirectional text** — each note can follow its content automatically or be
+  forced left-to-right or right-to-left from the direction menu in its header.
+  The choice also applies in the All Notes editor and survives archive exports.
 - **Multi-display & relocation** — show the deck on all displays, only the main
   screen, or a specific monitor. Hold `⌥ Option` and drag the pill to dock it to
   any edge, height, or display. Displays are tracked by `CGDirectDisplayID`, so

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -164,6 +164,53 @@ enum Ink {
 
 // MARK: - Model
 
+enum NoteTextDirection: String, Codable, CaseIterable, Identifiable {
+    case automatic
+    case leftToRight
+    case rightToLeft
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .automatic:   "Automatic"
+        case .leftToRight: "Left to Right"
+        case .rightToLeft: "Right to Left"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .automatic:   "textformat"
+        case .leftToRight: "text.alignleft"
+        case .rightToLeft: "text.alignright"
+        }
+    }
+
+    var writingDirection: NSWritingDirection {
+        switch self {
+        case .automatic:   .natural
+        case .leftToRight: .leftToRight
+        case .rightToLeft: .rightToLeft
+        }
+    }
+
+    var alignment: NSTextAlignment {
+        switch self {
+        case .automatic:   .natural
+        case .leftToRight: .left
+        case .rightToLeft: .right
+        }
+    }
+
+    var paragraphStyle: NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.baseWritingDirection = writingDirection
+        style.alignment = alignment
+        return style
+    }
+}
+
 struct Note: Identifiable, Hashable {
     var id: String = UUID().uuidString
     var title: String = ""
@@ -173,6 +220,7 @@ struct Note: Identifiable, Hashable {
     var modified: Date = Date()
     var archived: Bool = false
     var pinned: Bool = false
+    var textDirection: NoteTextDirection = .automatic
     var order: Double = 0
 
     var palette: NoteColor { NoteColor.at(color) }

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -209,6 +209,48 @@ enum NoteTextDirection: String, Codable, CaseIterable, Identifiable {
         style.alignment = alignment
         return style
     }
+
+    /// Resolve Automatic from the first strong character in a paragraph.
+    /// AppKit's `.natural` alignment follows the app's locale on macOS rather
+    /// than reliably aligning each paragraph from its contents, so the editor
+    /// stores an explicit paragraph direction after inspecting the text.
+    func paragraphStyle(for paragraph: String) -> NSParagraphStyle {
+        guard self == .automatic else { return paragraphStyle }
+        let direction = Self.firstStrongDirection(in: paragraph) ?? .leftToRight
+        let style = NSMutableParagraphStyle()
+        style.baseWritingDirection = direction
+        style.alignment = direction == .rightToLeft ? .right : .left
+        return style
+    }
+
+    static func firstStrongDirection(in text: String) -> NSWritingDirection? {
+        for scalar in text.unicodeScalars {
+            switch scalar.value {
+            case 0x200E: return .leftToRight  // LEFT-TO-RIGHT MARK
+            case 0x061C, 0x200F: return .rightToLeft // ARABIC/RIGHT-TO-LEFT MARK
+            default: break
+            }
+
+            // Punctuation, whitespace, emoji, combining marks, and digits are
+            // neutral here; they must not decide the paragraph's direction.
+            guard scalar.properties.isAlphabetic else { continue }
+            return Self.isRightToLeftLetter(scalar.value) ? .rightToLeft : .leftToRight
+        }
+        return nil
+    }
+
+    private static func isRightToLeftLetter(_ value: UInt32) -> Bool {
+        switch value {
+        case 0x0590...0x08FF,   // Hebrew, Arabic, Syriac, Thaana, N'Ko, etc.
+             0xFB1D...0xFDFF,   // Hebrew and Arabic presentation forms
+             0xFE70...0xFEFF,   // Arabic presentation forms B
+             0x10800...0x10FFF, // historic right-to-left scripts
+             0x1E800...0x1EEFF: // Mende, Adlam, Arabic mathematical letters
+            true
+        default:
+            false
+        }
+    }
 }
 
 struct Note: Identifiable, Hashable {

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -179,9 +179,9 @@ enum NoteTextDirection: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    var symbol: String {
+    var symbol: String? {
         switch self {
-        case .automatic:   "textformat"
+        case .automatic:   nil
         case .leftToRight: "text.alignleft"
         case .rightToLeft: "text.alignright"
         }

--- a/Sources/EditorStyleEngine.swift
+++ b/Sources/EditorStyleEngine.swift
@@ -103,10 +103,13 @@ enum EditorStyleEngine {
                       ink: NSColor,
                       size: CGFloat,
                       markdownEnabled: Bool,
+                      textDirection: NoteTextDirection = .automatic,
                       bodyFont: @escaping FontProvider,
                       isCompletedTask: @escaping CompletedTaskPredicate) -> [NSRange] {
         let font = bodyFont(size)
-        textView.typingAttributes = [.font: font, .foregroundColor: ink]
+        let paragraphStyle = textDirection.paragraphStyle
+        textView.typingAttributes = [.font: font, .foregroundColor: ink,
+                                     .paragraphStyle: paragraphStyle]
 
         guard let storage = textView.textStorage else { return [] }
         let planned = normalizedStyleRanges(ranges, length: storage.length)
@@ -128,6 +131,7 @@ enum EditorStyleEngine {
             storage.removeAttribute(.link, range: range)
             storage.addAttribute(.foregroundColor, value: ink, range: range)
             storage.addAttribute(.font, value: font, range: range)
+            storage.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
 
             let fragment = storage.mutableString.substring(with: range)
             if markdownEnabled {

--- a/Sources/EditorStyleEngine.swift
+++ b/Sources/EditorStyleEngine.swift
@@ -131,7 +131,7 @@ enum EditorStyleEngine {
             storage.removeAttribute(.link, range: range)
             storage.addAttribute(.foregroundColor, value: ink, range: range)
             storage.addAttribute(.font, value: font, range: range)
-            storage.addAttribute(.paragraphStyle, value: paragraphStyle, range: range)
+            applyParagraphStyles(to: storage, range: range, direction: textDirection)
 
             let fragment = storage.mutableString.substring(with: range)
             if markdownEnabled {
@@ -152,6 +152,31 @@ enum EditorStyleEngine {
             textView.layoutManager?.invalidateDisplay(forCharacterRange: range)
         }
         return planned
+    }
+
+    /// Apply Automatic independently to every paragraph so mixed-language
+    /// notes can contain both English and Arabic/Hebrew paragraphs naturally.
+    private static func applyParagraphStyles(to storage: NSTextStorage,
+                                             range: NSRange,
+                                             direction: NoteTextDirection) {
+        guard direction == .automatic else {
+            storage.addAttribute(.paragraphStyle, value: direction.paragraphStyle, range: range)
+            return
+        }
+
+        let text = storage.mutableString
+        let upperBound = NSMaxRange(range)
+        var location = range.location
+        while location < upperBound {
+            let paragraph = text.paragraphRange(for: NSRange(location: location, length: 0))
+            let target = NSIntersectionRange(paragraph, range)
+            guard target.length > 0 else { break }
+            let contents = text.substring(with: paragraph)
+            storage.addAttribute(.paragraphStyle,
+                                 value: direction.paragraphStyle(for: contents),
+                                 range: target)
+            location = NSMaxRange(target)
+        }
     }
 
     /// The only characters any of the expressions below can match on. A link

--- a/Sources/ExportImport.swift
+++ b/Sources/ExportImport.swift
@@ -4,7 +4,7 @@ import UniformTypeIdentifiers
 // MARK: - Archive format
 
 struct StickyArchive: Codable {
-    var version = 1
+    var version = 2
     var app = "Noty"
     var exported = Date()
     var notes: [StickyNote]
@@ -20,18 +20,21 @@ struct StickyNote: Codable {
     var modified: Date
     var archived: Bool
     var order: Double
+    var textDirection: NoteTextDirection?
 
     init(_ n: Note) {
         id = n.id; title = n.title; body = n.body
         color = n.color; colorName = n.palette.name
         created = n.created; modified = n.modified
         archived = n.archived; order = n.order
+        textDirection = n.textDirection
     }
 
     var note: Note {
         Note(id: id, title: title.isEmpty ? Note.derivedTitle(from: body) : title,
              body: body, color: color, created: created, modified: modified,
-             archived: archived, order: order)
+             archived: archived, textDirection: textDirection ?? .automatic,
+             order: order)
     }
 }
 

--- a/Sources/LibraryWindow.swift
+++ b/Sources/LibraryWindow.swift
@@ -277,6 +277,11 @@ struct LibraryDetail: View {
                 Text("Edited \(Fmt.ago(note.modified))")
                     .font(.system(size: 10.5)).foregroundStyle(.secondary)
 
+                NoteTextDirectionMenu(direction: note.textDirection) {
+                    NoteStore.shared.setTextDirection(id: note.id, direction: $0)
+                }
+                .foregroundStyle(.secondary)
+
                 if note.archived {
                     Button("Restore") { NoteStore.shared.setArchived(id: note.id, false) }
                         .controlSize(.small)
@@ -299,6 +304,7 @@ struct LibraryDetail: View {
             NoteTextView(text: $text, ink: NSColor(pal.ink), bridge: bridge,
                          autofocus: false, fontSize: Settings.noteFontSize,
                          markdownEnabled: Settings.markdownStyling,
+                         textDirection: note.textDirection,
                          styleToken: "\(note.color)|\(Settings.noteFontSize)|\(Settings.noteFontName)|\(Settings.markdownStyling)")
                 .background(pal.paper)
         }

--- a/Sources/LibraryWindow.swift
+++ b/Sources/LibraryWindow.swift
@@ -277,10 +277,10 @@ struct LibraryDetail: View {
                 Text("Edited \(Fmt.ago(note.modified))")
                     .font(.system(size: 10.5)).foregroundStyle(.secondary)
 
-                NoteTextDirectionMenu(direction: note.textDirection) {
+                NoteTextDirectionMenu(direction: note.textDirection,
+                                      foreground: .secondary) {
                     NoteStore.shared.setTextDirection(id: note.id, direction: $0)
                 }
-                .foregroundStyle(.secondary)
 
                 if note.archived {
                     Button("Restore") { NoteStore.shared.setArchived(id: note.id, false) }

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -550,6 +550,9 @@ struct NoteTextDirectionMenu: View {
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
+        // Borderless menus use the control tint for their label on macOS,
+        // overriding the label's foreground style (most visibly for "Auto").
+        .tint(foreground)
         .fixedSize()
         .help("Text direction: \(direction.title)")
     }
@@ -661,7 +664,7 @@ struct NoteEditorView: View {
             .help(note.pinned ? "Unpin — ⌘P" : "Pin so it stays open  ⌘P")
 
             NoteTextDirectionMenu(direction: note.textDirection,
-                                  foreground: pal.ink.opacity(0.72)) {
+                                  foreground: pal.ink.opacity(0.5)) {
                 NoteStore.shared.setTextDirection(id: note.id, direction: $0)
             }
 

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -291,6 +291,11 @@ struct NoteTextView: NSViewRepresentable {
     }
 
     static func applyTextDirection(_ direction: NoteTextDirection, to textView: NSTextView) {
+        // Automatic is applied per paragraph by EditorStyleEngine. Assigning
+        // NSTextView.alignment/baseWritingDirection here would rewrite every
+        // paragraph back to AppKit's locale-based `.natural` alignment after
+        // the engine had resolved its first strong character.
+        guard direction != .automatic else { return }
         textView.baseWritingDirection = direction.writingDirection
         textView.alignment = direction.alignment
     }

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -205,6 +205,7 @@ struct NoteTextView: NSViewRepresentable {
     var autofocus: Bool
     var fontSize: CGFloat = 13.5
     var markdownEnabled: Bool = Settings.markdownStyling
+    var textDirection: NoteTextDirection = .automatic
     /// Everything that affects how the text is drawn, as one cheap value. The
     /// alternative — comparing a freshly built NSColor and NSFont — is not
     /// reliably equal, so a full restyle ran on every re-render.
@@ -256,7 +257,6 @@ struct NoteTextView: NSViewRepresentable {
         tv.linkTextAttributes = [.underlineStyle: NSUnderlineStyle.single.rawValue,
                                  .cursor: NSCursor.pointingHand]
         tv.string = text
-
         scroll.documentView = tv
         bridge.textView = tv
         let activeLine = EditorStyleEngine.lineRange(
@@ -266,7 +266,9 @@ struct NoteTextView: NSViewRepresentable {
                          revealing: activeLine,
                          ink: ink,
                          size: fontSize,
-                         markdownEnabled: markdownEnabled)
+                         markdownEnabled: markdownEnabled,
+                         textDirection: textDirection)
+        Self.applyTextDirection(textDirection, to: tv)
         context.coordinator.attach(to: tv)
         if autofocus {
             DispatchQueue.main.async { tv.window?.makeFirstResponder(tv) }
@@ -278,6 +280,7 @@ struct NoteTextView: NSViewRepresentable {
         guard let tv = scroll.documentView as? NSTextView else { return }
         context.coordinator.parent = self
         context.coordinator.synchronize(tv)
+        Self.applyTextDirection(textDirection, to: tv)
         if bridge.textView !== tv { bridge.textView = tv }
     }
 
@@ -287,19 +290,26 @@ struct NoteTextView: NSViewRepresentable {
         tv.textStorage?.delegate = nil
     }
 
+    static func applyTextDirection(_ direction: NoteTextDirection, to textView: NSTextView) {
+        textView.baseWritingDirection = direction.writingDirection
+        textView.alignment = direction.alignment
+    }
+
     @discardableResult
     private static func applyStyles(to tv: NSTextView,
                                     ranges: [NSRange],
                                     revealing activeLine: NSRange?,
                                     ink: NSColor,
                                     size: CGFloat,
-                                    markdownEnabled: Bool) -> [NSRange] {
+                                    markdownEnabled: Bool,
+                                    textDirection: NoteTextDirection) -> [NSRange] {
         EditorStyleEngine.apply(to: tv,
                                 ranges: ranges,
                                 revealing: activeLine,
                                 ink: ink,
                                 size: size,
                                 markdownEnabled: markdownEnabled,
+                                textDirection: textDirection,
                                 bodyFont: bodyFont,
                                 isCompletedTask: { Tasks.marker(of: $0) == Tasks.done })
     }
@@ -415,7 +425,8 @@ struct NoteTextView: NSViewRepresentable {
                                      revealing: line,
                                      ink: parent.ink,
                                      size: parent.fontSize,
-                                     markdownEnabled: parent.markdownEnabled)
+                                     markdownEnabled: parent.markdownEnabled,
+                                     textDirection: parent.textDirection)
             isApplyingStyles = false
             lastLine = line
             if invalidateCursors { tv.window?.invalidateCursorRects(for: tv) }
@@ -438,7 +449,8 @@ struct NoteTextView: NSViewRepresentable {
                                      revealing: line,
                                      ink: parent.ink,
                                      size: parent.fontSize,
-                                     markdownEnabled: parent.markdownEnabled)
+                                     markdownEnabled: parent.markdownEnabled,
+                                     textDirection: parent.textDirection)
             isApplyingStyles = false
 
             edits.clear()
@@ -457,11 +469,15 @@ struct NoteTextView: NSViewRepresentable {
         }
 
         private func configurationChanged() -> Bool {
-            appliedStyle != parent.styleToken
+            appliedStyle != configurationToken
         }
 
         private func rememberConfiguration() {
-            appliedStyle = parent.styleToken
+            appliedStyle = configurationToken
+        }
+
+        private var configurationToken: String {
+            "\(parent.styleToken)|\(parent.textDirection.rawValue)"
         }
 
         private func clamped(_ selection: NSRange, to length: Int) -> NSRange {
@@ -496,6 +512,30 @@ struct NoteTextView: NSViewRepresentable {
 }
 
 // MARK: - Editor
+
+struct NoteTextDirectionMenu: View {
+    let direction: NoteTextDirection
+    let select: (NoteTextDirection) -> Void
+
+    var body: some View {
+        Menu {
+            ForEach(NoteTextDirection.allCases) { option in
+                Button(option == direction ? "✓ \(option.title)" : option.title) {
+                    select(option)
+                }
+            }
+        } label: {
+            Image(systemName: direction.symbol)
+                .font(.system(size: 11, weight: .semibold))
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Text direction: \(direction.title)")
+    }
+}
 
 struct NoteEditorView: View {
     let note: Note
@@ -547,6 +587,7 @@ struct NoteEditorView: View {
                          bridge: deck.bridge, autofocus: true,
                          fontSize: deck.fontSize,
                          markdownEnabled: deck.markdown,
+                         textDirection: note.textDirection,
                          styleToken: "\(note.color)|\(deck.fontSize)|\(Settings.noteFontName)|\(deck.markdown)")
             footer
         }
@@ -600,6 +641,11 @@ struct NoteEditorView: View {
             .buttonStyle(.plain)
             .foregroundStyle(pal.ink.opacity(note.pinned ? 0.85 : 0.4))
             .help(note.pinned ? "Unpin — ⌘P" : "Pin so it stays open  ⌘P")
+
+            NoteTextDirectionMenu(direction: note.textDirection) {
+                NoteStore.shared.setTextDirection(id: note.id, direction: $0)
+            }
+            .foregroundStyle(pal.ink.opacity(0.5))
 
             Button { deck.bridge.toggleTaskLine() } label: {
                 Image(systemName: "checklist")

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -513,8 +513,29 @@ struct NoteTextView: NSViewRepresentable {
 
 // MARK: - Editor
 
+struct NoteTextDirectionLabel: View {
+    let direction: NoteTextDirection
+    let foreground: Color
+
+    var body: some View {
+        Group {
+            if let symbol = direction.symbol {
+                Image(systemName: symbol)
+                    .font(.system(size: 11, weight: .semibold))
+            } else {
+                Text("Auto")
+                    .font(.system(size: 9.5, weight: .semibold))
+            }
+        }
+        .foregroundStyle(foreground)
+        .frame(width: direction == .automatic ? 27 : 18, height: 18)
+        .contentShape(Rectangle())
+    }
+}
+
 struct NoteTextDirectionMenu: View {
     let direction: NoteTextDirection
+    let foreground: Color
     let select: (NoteTextDirection) -> Void
 
     var body: some View {
@@ -525,10 +546,7 @@ struct NoteTextDirectionMenu: View {
                 }
             }
         } label: {
-            Image(systemName: direction.symbol)
-                .font(.system(size: 11, weight: .semibold))
-                .frame(width: 18, height: 18)
-                .contentShape(Rectangle())
+            NoteTextDirectionLabel(direction: direction, foreground: foreground)
         }
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
@@ -642,10 +660,10 @@ struct NoteEditorView: View {
             .foregroundStyle(pal.ink.opacity(note.pinned ? 0.85 : 0.4))
             .help(note.pinned ? "Unpin — ⌘P" : "Pin so it stays open  ⌘P")
 
-            NoteTextDirectionMenu(direction: note.textDirection) {
+            NoteTextDirectionMenu(direction: note.textDirection,
+                                  foreground: pal.ink.opacity(0.72)) {
                 NoteStore.shared.setTextDirection(id: note.id, direction: $0)
             }
-            .foregroundStyle(pal.ink.opacity(0.5))
 
             Button { deck.bridge.toggleTaskLine() } label: {
                 Image(systemName: "checklist")

--- a/Sources/NoteStore.swift
+++ b/Sources/NoteStore.swift
@@ -73,6 +73,14 @@ final class NoteStore: ObservableObject {
         store.upsert(notes[i])
     }
 
+    func setTextDirection(id: String, direction: NoteTextDirection) {
+        guard let i = notes.firstIndex(where: { $0.id == id }),
+              notes[i].textDirection != direction else { return }
+        notes[i].textDirection = direction
+        notes[i].modified = Date()
+        store.upsert(notes[i])
+    }
+
     func setArchived(id: String, _ archived: Bool) {
         guard let i = notes.firstIndex(where: { $0.id == id }) else { return }
         notes[i].archived = archived

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -8,11 +8,11 @@ private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.sel
 final class Store {
     private var db: OpaquePointer?
 
-    init() {
-        if sqlite3_open_v2(Paths.db.path, &db,
+    init(dbURL: URL = Paths.db) {
+        if sqlite3_open_v2(dbURL.path, &db,
                            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
                            nil) != SQLITE_OK {
-            NSLog("Noty: cannot open db at \(Paths.db.path)")
+            NSLog("Noty: cannot open db at \(dbURL.path)")
         }
         exec("PRAGMA journal_mode=WAL;")
         exec("PRAGMA synchronous=NORMAL;")
@@ -25,7 +25,9 @@ final class Store {
           created REAL NOT NULL,
           modified REAL NOT NULL,
           archived INTEGER NOT NULL DEFAULT 0,
-          sort_order REAL NOT NULL DEFAULT 0
+          sort_order REAL NOT NULL DEFAULT 0,
+          pinned INTEGER NOT NULL DEFAULT 0,
+          text_direction TEXT NOT NULL DEFAULT 'automatic'
         );
         """)
         exec("CREATE INDEX IF NOT EXISTS idx_notes_archived ON notes(archived, sort_order);")
@@ -47,6 +49,10 @@ final class Store {
             exec("ALTER TABLE notes ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;")
             NSLog("Noty: migrated notes table — added pinned")
         }
+        if !existing.contains("text_direction") {
+            exec("ALTER TABLE notes ADD COLUMN text_direction TEXT NOT NULL DEFAULT 'automatic';")
+            NSLog("Noty: migrated notes table — added text direction")
+        }
     }
 
     deinit { if let db { sqlite3_close_v2(db) } }
@@ -64,7 +70,7 @@ final class Store {
     func load() -> [Note] {
         var out: [Note] = []
         var st: OpaquePointer?
-        let sql = "SELECT id,title,body,color,created,modified,archived,sort_order,pinned FROM notes ORDER BY sort_order ASC;"
+        let sql = "SELECT id,title,body,color,created,modified,archived,sort_order,pinned,text_direction FROM notes ORDER BY sort_order ASC;"
         guard sqlite3_prepare_v2(db, sql, -1, &st, nil) == SQLITE_OK else { return out }
         defer { sqlite3_finalize(st) }
         while sqlite3_step(st) == SQLITE_ROW {
@@ -81,6 +87,8 @@ final class Store {
             n.archived = sqlite3_column_int(st, 6) != 0
             n.order = sqlite3_column_double(st, 7)
             n.pinned = sqlite3_column_int(st, 8) != 0
+            let rawDirection = sqlite3_column_text(st, 9).map { String(cString: $0) }
+            n.textDirection = rawDirection.flatMap(NoteTextDirection.init(rawValue:)) ?? .automatic
             out.append(n)
         }
         return out
@@ -90,12 +98,13 @@ final class Store {
 
     func upsert(_ n: Note) {
         let sql = """
-        INSERT INTO notes (id,title,body,color,created,modified,archived,sort_order,pinned)
-        VALUES (?,?,?,?,?,?,?,?,?)
+        INSERT INTO notes (id,title,body,color,created,modified,archived,sort_order,pinned,text_direction)
+        VALUES (?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
           title=excluded.title, body=excluded.body, color=excluded.color,
           modified=excluded.modified, archived=excluded.archived,
-          sort_order=excluded.sort_order, pinned=excluded.pinned;
+          sort_order=excluded.sort_order, pinned=excluded.pinned,
+          text_direction=excluded.text_direction;
         """
         var st: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &st, nil) == SQLITE_OK else { return }
@@ -112,6 +121,7 @@ final class Store {
         sqlite3_bind_int(st, 7, n.archived ? 1 : 0)
         sqlite3_bind_double(st, 8, n.order)
         sqlite3_bind_int(st, 9, n.pinned ? 1 : 0)
+        sqlite3_bind_text(st, 10, n.textDirection.rawValue, -1, SQLITE_TRANSIENT)
         if sqlite3_step(st) != SQLITE_DONE {
             NSLog("Noty: upsert failed — \(String(cString: sqlite3_errmsg(db)))")
         }

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Darwin
+import SQLite3
 import SwiftUI
 
 @main
@@ -19,6 +20,9 @@ struct EditorStyleEngineTests {
         testMarkdownLinks()
         testStaleLinkAttributesAreCleared()
         testLongNotePlanningStaysLocal()
+        testTextDirectionConfiguration()
+        testLegacyArchiveDefaultsToAutomaticDirection()
+        testTextDirectionDatabaseMigration()
 
         guard failures == 0 else {
             fputs("EditorStyleEngineTests: \(failures) failure(s)\n", stderr)
@@ -32,6 +36,123 @@ struct EditorStyleEngineTests {
         guard !condition() else { return }
         failures += 1
         fputs("\(file):\(line): failure: \(message)\n", stderr)
+    }
+
+    private static func testTextDirectionConfiguration() {
+        let source = "English العربية עברית"
+        let tv = makeTextView(source)
+        let selection = NSRange(location: 4, length: 3)
+        tv.setSelectedRange(selection)
+
+        for direction in NoteTextDirection.allCases {
+            NoteTextView.applyTextDirection(direction, to: tv)
+            _ = EditorStyleEngine.apply(
+                to: tv,
+                ranges: [NSRange(location: 0, length: (source as NSString).length)],
+                revealing: nil,
+                ink: .textColor,
+                size: 13.5,
+                markdownEnabled: true,
+                textDirection: direction,
+                bodyFont: { NSFont.systemFont(ofSize: $0) },
+                isCompletedTask: { _ in false })
+            check(tv.baseWritingDirection == direction.writingDirection,
+                  "text view must apply \(direction.title) as its base writing direction")
+            check(tv.alignment == direction.alignment,
+                  "text view must apply \(direction.title) alignment")
+            let paragraph = tv.textStorage?.attribute(.paragraphStyle, at: 0,
+                                                       effectiveRange: nil) as? NSParagraphStyle
+            check(paragraph?.baseWritingDirection == direction.writingDirection,
+                  "restyling must preserve \(direction.title) writing direction")
+            check(paragraph?.alignment == direction.alignment,
+                  "restyling must preserve \(direction.title) paragraph alignment")
+            check(tv.string == source, "changing direction must not mutate note text")
+            check(tv.selectedRange() == selection,
+                  "changing direction must preserve the editor selection")
+        }
+    }
+
+    private struct LegacyStickyNote: Codable {
+        var id = "legacy"
+        var title = ""
+        var body = "مرحبا"
+        var color = 0
+        var colorName = "Lemon"
+        var created = Date(timeIntervalSince1970: 1)
+        var modified = Date(timeIntervalSince1970: 2)
+        var archived = false
+        var order = 0.0
+    }
+
+    private static func testLegacyArchiveDefaultsToAutomaticDirection() {
+        do {
+            let data = try JSONEncoder().encode(LegacyStickyNote())
+            let decoded = try JSONDecoder().decode(StickyNote.self, from: data)
+            check(decoded.textDirection == nil,
+                  "archives created before direction support must still decode")
+            check(decoded.note.textDirection == .automatic,
+                  "legacy archives must import with automatic direction")
+        } catch {
+            check(false, "legacy archive decoding failed: \(error)")
+        }
+    }
+
+    private static func testTextDirectionDatabaseMigration() {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("noty-migration-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("notes.db")
+        do {
+            try FileManager.default.createDirectory(at: directory,
+                                                    withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+
+            var db: OpaquePointer?
+            guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+                check(false, "test database must open")
+                return
+            }
+            let legacySchema = """
+            CREATE TABLE notes (
+              id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '', body BLOB NOT NULL,
+              color INTEGER NOT NULL DEFAULT 0, created REAL NOT NULL,
+              modified REAL NOT NULL, archived INTEGER NOT NULL DEFAULT 0,
+              sort_order REAL NOT NULL DEFAULT 0, pinned INTEGER NOT NULL DEFAULT 0
+            );
+            """
+            check(sqlite3_exec(db, legacySchema, nil, nil, nil) == SQLITE_OK,
+                  "legacy schema setup must succeed")
+            sqlite3_close(db)
+
+            let migratedStore = Store(dbURL: url)
+            _ = migratedStore
+
+            db = nil
+            guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+                check(false, "migrated database must reopen")
+                return
+            }
+            defer { sqlite3_close(db) }
+
+            check(sqlite3_exec(db,
+                               "INSERT INTO notes (id,body,created,modified) VALUES ('legacy',X'00',1,1);",
+                               nil, nil, nil) == SQLITE_OK,
+                  "rows written after migration must receive the direction default")
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db,
+                                     "SELECT text_direction FROM notes WHERE id='legacy';",
+                                     -1, &statement, nil) == SQLITE_OK else {
+                check(false, "migrated direction column must be queryable")
+                return
+            }
+            defer { sqlite3_finalize(statement) }
+            check(sqlite3_step(statement) == SQLITE_ROW,
+                  "migrated database must return the inserted row")
+            let raw = sqlite3_column_text(statement, 0).map { String(cString: $0) }
+            check(raw == NoteTextDirection.automatic.rawValue,
+                  "existing databases must default migrated notes to automatic direction")
+        } catch {
+            check(false, "migration test setup failed: \(error)")
+        }
     }
 
     private static func testSingleCharacterScope() {

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -56,20 +56,53 @@ struct EditorStyleEngineTests {
                 textDirection: direction,
                 bodyFont: { NSFont.systemFont(ofSize: $0) },
                 isCompletedTask: { _ in false })
-            check(tv.baseWritingDirection == direction.writingDirection,
+            let expectedParagraphDirection: NSWritingDirection =
+                direction == .automatic ? .leftToRight : direction.writingDirection
+            let expectedParagraphAlignment: NSTextAlignment =
+                direction == .automatic ? .left : direction.alignment
+            check(tv.baseWritingDirection == expectedParagraphDirection,
                   "text view must apply \(direction.title) as its base writing direction")
-            check(tv.alignment == direction.alignment,
+            check(tv.alignment == expectedParagraphAlignment,
                   "text view must apply \(direction.title) alignment")
             let paragraph = tv.textStorage?.attribute(.paragraphStyle, at: 0,
                                                        effectiveRange: nil) as? NSParagraphStyle
-            check(paragraph?.baseWritingDirection == direction.writingDirection,
+            check(paragraph?.baseWritingDirection == expectedParagraphDirection,
                   "restyling must preserve \(direction.title) writing direction")
-            check(paragraph?.alignment == direction.alignment,
+            check(paragraph?.alignment == expectedParagraphAlignment,
                   "restyling must preserve \(direction.title) paragraph alignment")
             check(tv.string == source, "changing direction must not mutate note text")
             check(tv.selectedRange() == selection,
                   "changing direction must preserve the editor selection")
         }
+
+        let mixedParagraphs = "  123 مرحبا بالعالم\n... Hello world\n# שלום עולם"
+        let mixed = makeTextView(mixedParagraphs)
+        _ = EditorStyleEngine.apply(
+            to: mixed,
+            ranges: [NSRange(location: 0, length: (mixedParagraphs as NSString).length)],
+            revealing: nil,
+            ink: .textColor,
+            size: 13.5,
+            markdownEnabled: true,
+            textDirection: .automatic,
+            bodyFont: { NSFont.systemFont(ofSize: $0) },
+            isCompletedTask: { _ in false })
+
+        let ns = mixedParagraphs as NSString
+        let arabic = mixed.textStorage?.attribute(.paragraphStyle, at: 0,
+                                                   effectiveRange: nil) as? NSParagraphStyle
+        let englishLocation = ns.range(of: "Hello").location
+        let english = mixed.textStorage?.attribute(.paragraphStyle, at: englishLocation,
+                                                    effectiveRange: nil) as? NSParagraphStyle
+        let hebrewLocation = ns.range(of: "שלום").location
+        let hebrew = mixed.textStorage?.attribute(.paragraphStyle, at: hebrewLocation,
+                                                   effectiveRange: nil) as? NSParagraphStyle
+        check(arabic?.baseWritingDirection == .rightToLeft && arabic?.alignment == .right,
+              "Automatic must resolve an Arabic paragraph from its first strong character")
+        check(english?.baseWritingDirection == .leftToRight && english?.alignment == .left,
+              "Automatic must resolve an English paragraph from its first strong character")
+        check(hebrew?.baseWritingDirection == .rightToLeft && hebrew?.alignment == .right,
+              "Automatic must resolve a Hebrew paragraph after neutral Markdown punctuation")
     }
 
     private struct LegacyStickyNote: Codable {

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -88,6 +88,11 @@ struct EditorStyleEngineTests {
             bodyFont: { NSFont.systemFont(ofSize: $0) },
             isCompletedTask: { _ in false })
 
+        // The live wrapper applies this after the initial style pass. Automatic
+        // must leave the per-paragraph results intact rather than replacing
+        // them with NSTextView's locale-based natural alignment.
+        NoteTextView.applyTextDirection(.automatic, to: mixed)
+
         let ns = mixedParagraphs as NSString
         let arabic = mixed.textStorage?.attribute(.paragraphStyle, at: 0,
                                                    effectiveRange: nil) as? NSParagraphStyle


### PR DESCRIPTION
## Summary

Adds a per-note text-direction control with three modes:

- **Auto** — resolves every paragraph independently from its first strong character
- **Left to Right** — forces left-to-right writing direction and left alignment
- **Right to Left** — forces right-to-left writing direction and right alignment

The control is available in both the edge editor and **All Notes**. Each note remembers its own selection.

## Why

Noty previously behaved as a left-to-right editor, which made Persian, Arabic, Hebrew, and mixed-language notes difficult to write and read. A note can also contain paragraphs in different scripts, so Auto needs to resolve direction per paragraph rather than once for the entire note.

## Implementation

### Native text behavior

- Applies `NSWritingDirection` and `NSTextAlignment` through native `NSTextView` paragraph styles.
- Auto scans past neutral content such as whitespace, digits, punctuation, emoji, and Markdown markers, then uses the first strong character.
- Auto is recalculated independently for each paragraph, allowing English and RTL paragraphs in the same note.
- Incremental editor styling reapplies direction only to affected paragraph ranges, preserving the existing scoped styling behavior.
- The forced LTR and RTL modes continue to apply one explicit direction to the whole note.

During manual testing we found that assigning `NSTextView.alignment = .natural` after styling silently replaced Auto's resolved paragraph alignment with the app-locale default. Auto therefore leaves the resolved paragraph styles intact; a regression test covers the live editor call order.

### Interface

- Adds a compact direction menu to the note header and All Notes detail view.
- Auto is represented by the text label **Auto**, avoiding an ambiguous symbol.
- LTR and RTL use the existing system alignment symbols.
- The edge-editor control uses the same palette ink color and opacity as the adjacent checklist/search controls, keeping it visible on bright note colors.

### Persistence and compatibility

- Adds a nullable-compatible `text_direction` SQLite column through the existing migration path.
- Existing databases default to Auto without losing or rewriting note content.
- Updates `.stickies` export archives to version 2 and preserves each note's direction.
- Version 1 archives remain importable and default to Auto when the field is absent.

### Documentation

- Documents per-note Auto/LTR/RTL support in the README.

## Verification

- `./scripts/test-editor.sh`
- `MARKETING_VERSION=1.3.0-direction BUILD_NUMBER=79 ./build.sh release`
- Deep code-signature verification performed by the release build script
- Installed build 79 over the local test instance and verified the corrected behavior manually

Automated coverage includes:

- Arabic-first paragraphs resolving RTL
- Hebrew following neutral Markdown punctuation resolving RTL
- English-first paragraphs resolving LTR
- Mixed-direction paragraphs in one note
- Explicit LTR and RTL configuration
- Paragraph-style persistence through editor restyling
- Preservation of note text and selection when direction changes
- The post-style AppKit overwrite regression found during live testing
- Existing-database schema migration
- Legacy version 1 archive import

## Scope

This change adds no dependencies and does not alter note text. Direction is presentation metadata stored per note.
