### PR TITLE
Add localization for English and Simplified Chinese with language switching

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleName</key>            <string>Noty</string>
 	<key>CFBundleDisplayName</key>     <string>Noty</string>
+	<key>CFBundleDevelopmentRegion</key><string>en</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+	</array>
 	<key>CFBundleIdentifier</key>      <string>app.noty.Noty</string>
 	<key>CFBundleExecutable</key>      <string>Noty</string>
 	<key>CFBundleIconFile</key>        <string>AppIcon</string>

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,206 @@
+"about.body" = "Sticky notes docked to the edge of your screen.\n\n⌥⌘N  new note      ⌥⌘A  all notes      ⌥⌘L  archive\nIn a note — Esc closes, ⌘F finds, ⌘. cycles colour, ⌘⌫ deletes.\n\nNotes are stored locally in an SQLite database; bodies are encrypted with AES-GCM. Your notes never leave this Mac — the only network request the app makes is the update check, which you can switch off.";
+
+"action.archive" = "Archive";
+"action.close" = "Close";
+"action.cycle_colour" = "Cycle colour";
+"action.delete" = "Delete";
+"action.find" = "Find";
+"action.pin" = "Pin";
+"action.restore" = "Restore";
+"action.undo" = "Undo";
+"action.unpin" = "Unpin";
+
+"capture.hint" = "↩ save    ⇧↩ new line    esc cancel";
+"capture.title" = "Quick note";
+
+"color.lemon" = "Lemon";
+"color.peach" = "Peach";
+"color.rose" = "Rose";
+"color.lilac" = "Lilac";
+"color.sky" = "Sky";
+"color.mint" = "Mint";
+"color.sand" = "Sand";
+"color.slate" = "Slate";
+
+"date.just_now" = "just now";
+
+"deck_style.colour_chips" = "Colour chips";
+"deck_style.labelled_tabs" = "Labelled tabs";
+
+"direction.auto_short" = "Auto";
+"direction.automatic" = "Automatic";
+"direction.left_to_right" = "Left to Right";
+"direction.right_to_left" = "Right to Left";
+
+"display.all" = "All Displays";
+"display.main" = "Main Display";
+"display.named_main" = "%@ (Main)";
+"edge.left" = "Left";
+"edge.right" = "Right";
+
+"export.archive_filename" = "Noty Archive-%@.stickies";
+"export.choose_folder" = "Choose a folder for %ld %@ files.";
+"export.default_note_name" = "note-%@";
+"export.document_title" = "Noty export";
+"export.empty_body" = "There are no notes yet.";
+"export.empty_title" = "Nothing to export";
+"export.failed_title" = "Export failed";
+"export.here" = "Export Here";
+"export.incomplete_body" = "Wrote %1$ld of %2$@. See Console for details.";
+"export.incomplete_title" = "Export incomplete";
+"export.markdown_filename" = "Noty Export-%@.md";
+"export.markdown_per_note" = "Markdown (one file per note)…";
+"export.metadata" = "%1$@ · created %2$@ · modified %3$@%4$@";
+"export.metadata_archived_suffix" = " · archived";
+"export.plain_per_note" = "Plain text (one file per note)…";
+"export.single_document" = "Single document…";
+"export.sticky_archive" = "Sticky archive (.stickies)…";
+
+"font.system" = "System";
+
+"help.cycle_colour" = "Cycle colour  ⌘.";
+"help.find" = "Find  ⌘F";
+"help.new_note" = "New Note  ⌥⌘N";
+"help.pick_colour" = "Cycle colour · right-click to pick";
+"help.pin" = "Pin so it stays open  ⌘P";
+"help.settings" = "Settings  ⌘,";
+"help.task" = "Task  ⌘T";
+"help.text_direction" = "Text direction: %@";
+"help.unpin" = "Unpin — ⌘P";
+
+"import.added" = "Added %ld notes.";
+"import.choose_files" = "Choose a .stickies archive, or Markdown / text files.";
+"import.complete_title" = "Import complete";
+"import.problems_body" = "%1$@ Could not read: %2$@";
+"import.problems_title" = "Import finished with problems";
+
+"key.escape" = "esc";
+"key.space" = "Space";
+"key.unknown" = "key %u";
+
+"language.english" = "English";
+"language.simplified_chinese" = "简体中文";
+"language.system" = "System Default";
+
+"library.all_notes" = "All Notes";
+"library.archive" = "Archive";
+"library.no_archive" = "Nothing archived";
+"library.no_matches" = "No matches";
+"library.no_notes" = "No notes yet";
+"library.search_placeholder" = "Search all notes";
+"library.select_note" = "Select a note";
+
+"menu.about" = "About Noty";
+"menu.all_notes" = "All Notes";
+"menu.archive" = "Archive";
+"menu.bigger_text" = "Bigger Text";
+"menu.check_automatically" = "Check automatically";
+"menu.check_for_updates" = "Check for Updates…";
+"menu.copy" = "Copy";
+"menu.cut" = "Cut";
+"menu.deck_size" = "Deck size";
+"menu.deck_style" = "Deck style";
+"menu.display" = "Display";
+"menu.dock_left" = "Dock deck to left edge";
+"menu.edit" = "Edit";
+"menu.export" = "Export";
+"menu.hide" = "Hide Noty";
+"menu.import" = "Import…";
+"menu.keep_deck_open" = "Keep deck open";
+"menu.launch_at_login" = "Launch at login";
+"menu.new_note" = "New Note";
+"menu.note_font" = "Note font";
+"menu.paste" = "Paste";
+"menu.quit" = "Quit Noty";
+"menu.redo" = "Redo";
+"menu.select_all" = "Select All";
+"menu.settings" = "Settings…";
+"menu.show_over_fullscreen" = "Show over full-screen apps";
+"menu.smaller_text" = "Smaller Text";
+"menu.text_size" = "Text size";
+"menu.undo" = "Undo";
+
+"note.edited" = "Edited %@";
+"note.empty" = "Empty note";
+"note.find_placeholder" = "Find in note";
+"note.new_tab" = "New note";
+"note.not_saved" = "Not saved";
+"note.saved" = "Saved · %@";
+"note.untitled" = "New note";
+"notes.count" = "%ld notes";
+"notes.more" = "%ld more notes";
+
+"settings.deck.caption" = "How the notes sit on the screen edge.";
+"settings.deck.detection_area" = "Detection area";
+"settings.deck.detection_help" = "How far from the edge the pointer wakes the deck — %ld pt.";
+"settings.deck.display" = "Display";
+"settings.deck.drag_help" = "Hold ⌥ Option and drag the pill to move it to any screen, edge, or height.";
+"settings.deck.edge" = "Edge";
+"settings.deck.hover_open" = "Open a note by hovering its tab";
+"settings.deck.hover_open_help" = "Rest on a tab and it opens, no click needed. Off by default.";
+"settings.deck.hover_preview" = "Show preview on hover";
+"settings.deck.hover_preview_help" = "Hover over a tab to peek at its contents without opening it.";
+"settings.deck.keep_open" = "Keep the deck open";
+"settings.deck.keep_open_help" = "Tabs stay on the edge with their labels showing, instead of folding back into the pill when the pointer leaves.";
+"settings.deck.language" = "Language";
+"settings.deck.language_help" = "Noty restarts automatically when you change the language.";
+"settings.deck.size" = "Size";
+"settings.deck.size_help" = "Scales the tabs, their labels, the chips and the resting pill together.";
+"settings.deck.style" = "Style";
+"settings.deck.tab" = "Deck";
+
+"settings.notes.caption" = "Type and formatting inside a note.";
+"settings.notes.font" = "Font";
+"settings.notes.font_size_value" = "%.1f pt";
+"settings.notes.markdown" = "Style Markdown as you type";
+"settings.notes.markdown_help" = "**bold**, *italic*, `code`, ~~struck~~, # headings, > quotes and [links](url), which ⌘-click opens. The text stays plain — only its appearance changes.";
+"settings.notes.note_size" = "Note size";
+"settings.notes.tab" = "Notes";
+"settings.notes.text_size" = "Text size";
+
+"settings.shortcuts.caption" = "Click a field and press the keys; ⌫ clears one.";
+"settings.shortcuts.global" = "From any app";
+"settings.shortcuts.hint" = "In-note shortcuts only fire while a note is open, so a key with no modifier is fine there.";
+"settings.shortcuts.in_note" = "In an open note";
+"settings.shortcuts.tab" = "Shortcuts";
+
+"settings.updates.automatic" = "Check for updates automatically";
+"settings.updates.caption" = "Noty fetches one file to see whether a newer version exists.";
+"settings.updates.check_now" = "Check Now";
+"settings.updates.privacy" = "Fetching appcast.xml is the only network request Noty ever makes — no accounts, no analytics, and nothing about a note leaves the Mac. Every update is checked against the EdDSA public key in the app; one signed by any other key is refused.";
+"settings.updates.tab" = "Updates";
+"settings.updates.this_copy" = "This copy";
+"settings.updates.version" = "Noty %1$@  (build %2$@)";
+"settings.window_title" = "Noty Settings";
+
+"shortcut.all_notes" = "All Notes";
+"shortcut.archive_note" = "Archive note";
+"shortcut.archive_window" = "Archive window";
+"shortcut.duplicate" = "Already used by another shortcut";
+"shortcut.new_note" = "New note";
+"shortcut.press_keys" = "Press keys…";
+"shortcut.quick_capture" = "Quick capture";
+"shortcut.toggle_task" = "Toggle task";
+
+"size.default" = "Default";
+"size.extra_large" = "Extra Large";
+"size.huge" = "Huge";
+"size.large" = "Large";
+"size.medium" = "Medium";
+"size.small" = "Small";
+
+"undo.note_deleted" = "Note deleted";
+
+"updates.install_sparkle" = "Run ./scripts/fetch-sparkle.sh and rebuild to add the updater.";
+"updates.last_checked" = "Last checked %@.";
+"updates.no_sparkle_status" = "This build has no Sparkle framework, so it cannot update itself.";
+"updates.not_checked" = "No check yet.";
+"updates.unavailable_body" = "This copy of Noty was built without the Sparkle framework. Run ./scripts/fetch-sparkle.sh and rebuild to enable automatic updates.";
+"updates.unavailable_title" = "Updates are not available in this build";
+
+"welcome.note_body" = "Welcome to Noty\n\nYour notes live at the edge of the screen. Slide the pointer to the right edge and the deck fans out.\n\n⌥⌘N  new note\n⌥⌘A  all notes\n⌥⌘L  archive\n\nInside a note: Esc closes, ⌘F finds, ⌘. cycles the colour, ⌘⌫ deletes with ten seconds to undo.";
+
+"width.narrow" = "Narrow";
+"width.standard" = "Standard";
+"width.very_wide" = "Very wide";
+"width.wide" = "Wide";

--- a/Resources/en.lproj/Localizable.stringsdict
+++ b/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>notes.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>%ld note</string>
+            <key>other</key>
+            <string>%ld notes</string>
+        </dict>
+    </dict>
+    <key>notes.more</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>%ld more note</string>
+            <key>other</key>
+            <string>%ld more notes</string>
+        </dict>
+    </dict>
+    <key>export.choose_folder</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>Choose a folder for %#@files@.</string>
+        <key>files</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>%ld %@ file</string>
+            <key>other</key>
+            <string>%ld %@ files</string>
+        </dict>
+    </dict>
+    <key>import.added</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>Added %ld note.</string>
+            <key>other</key>
+            <string>Added %ld notes.</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,206 @@
+"about.body" = "停靠在屏幕边缘的便笺。\n\n⌥⌘N  新建便笺      ⌥⌘A  所有便笺      ⌥⌘L  归档\n在便笺中 — Esc 关闭，⌘F 查找，⌘. 切换颜色，⌘⌫ 删除。\n\n便笺保存在本机的 SQLite 数据库中，正文使用 AES-GCM 加密。便笺绝不会离开这台 Mac；应用唯一的网络请求是更新检查，并且可以关闭。";
+
+"action.archive" = "归档";
+"action.close" = "关闭";
+"action.cycle_colour" = "切换颜色";
+"action.delete" = "删除";
+"action.find" = "查找";
+"action.pin" = "固定";
+"action.restore" = "恢复";
+"action.undo" = "撤销";
+"action.unpin" = "取消固定";
+
+"capture.hint" = "↩ 保存    ⇧↩ 换行    esc 取消";
+"capture.title" = "快速记录";
+
+"color.lemon" = "柠檬黄";
+"color.peach" = "蜜桃橙";
+"color.rose" = "玫瑰粉";
+"color.lilac" = "丁香紫";
+"color.sky" = "天空蓝";
+"color.mint" = "薄荷绿";
+"color.sand" = "沙褐色";
+"color.slate" = "石板灰";
+
+"date.just_now" = "刚刚";
+
+"deck_style.colour_chips" = "颜色标签";
+"deck_style.labelled_tabs" = "文字标签";
+
+"direction.auto_short" = "自动";
+"direction.automatic" = "自动";
+"direction.left_to_right" = "从左到右";
+"direction.right_to_left" = "从右到左";
+
+"display.all" = "所有显示器";
+"display.main" = "主显示器";
+"display.named_main" = "%@（主显示器）";
+"edge.left" = "左侧";
+"edge.right" = "右侧";
+
+"export.archive_filename" = "Noty 归档-%@.stickies";
+"export.choose_folder" = "请选择用于保存 %ld 个 %@ 文件的文件夹。";
+"export.default_note_name" = "便笺-%@";
+"export.document_title" = "Noty 导出";
+"export.empty_body" = "目前还没有便笺。";
+"export.empty_title" = "没有可导出的内容";
+"export.failed_title" = "导出失败";
+"export.here" = "导出到这里";
+"export.incomplete_body" = "已写入 %1$ld 个，共 %2$@。详情请查看“控制台”。";
+"export.incomplete_title" = "导出未完成";
+"export.markdown_filename" = "Noty 导出-%@.md";
+"export.markdown_per_note" = "Markdown（每篇便笺一个文件）…";
+"export.metadata" = "%1$@ · 创建于 %2$@ · 修改于 %3$@%4$@";
+"export.metadata_archived_suffix" = " · 已归档";
+"export.plain_per_note" = "纯文本（每篇便笺一个文件）…";
+"export.single_document" = "单个文稿…";
+"export.sticky_archive" = "便笺归档（.stickies）…";
+
+"font.system" = "系统字体";
+
+"help.cycle_colour" = "切换颜色  ⌘.";
+"help.find" = "查找  ⌘F";
+"help.new_note" = "新建便笺  ⌥⌘N";
+"help.pick_colour" = "切换颜色 · 右键点按可选取";
+"help.pin" = "固定并保持打开  ⌘P";
+"help.settings" = "设置  ⌘,";
+"help.task" = "任务  ⌘T";
+"help.text_direction" = "文本方向：%@";
+"help.unpin" = "取消固定 — ⌘P";
+
+"import.added" = "已添加 %ld 篇便笺。";
+"import.choose_files" = "请选择 .stickies 归档或 Markdown / 文本文件。";
+"import.complete_title" = "导入完成";
+"import.problems_body" = "%1$@ 无法读取：%2$@";
+"import.problems_title" = "导入完成，但遇到问题";
+
+"key.escape" = "esc";
+"key.space" = "空格";
+"key.unknown" = "按键 %u";
+
+"language.english" = "English";
+"language.simplified_chinese" = "简体中文";
+"language.system" = "跟随系统";
+
+"library.all_notes" = "所有便笺";
+"library.archive" = "归档";
+"library.no_archive" = "归档为空";
+"library.no_matches" = "没有匹配项";
+"library.no_notes" = "还没有便笺";
+"library.search_placeholder" = "搜索所有便笺";
+"library.select_note" = "选择一篇便笺";
+
+"menu.about" = "关于 Noty";
+"menu.all_notes" = "所有便笺";
+"menu.archive" = "归档";
+"menu.bigger_text" = "放大文本";
+"menu.check_automatically" = "自动检查";
+"menu.check_for_updates" = "检查更新…";
+"menu.copy" = "拷贝";
+"menu.cut" = "剪切";
+"menu.deck_size" = "便笺栏大小";
+"menu.deck_style" = "便笺栏样式";
+"menu.display" = "显示器";
+"menu.dock_left" = "将便笺栏停靠在左侧";
+"menu.edit" = "编辑";
+"menu.export" = "导出";
+"menu.hide" = "隐藏 Noty";
+"menu.import" = "导入…";
+"menu.keep_deck_open" = "保持便笺栏展开";
+"menu.launch_at_login" = "登录时启动";
+"menu.new_note" = "新建便笺";
+"menu.note_font" = "便笺字体";
+"menu.paste" = "粘贴";
+"menu.quit" = "退出 Noty";
+"menu.redo" = "重做";
+"menu.select_all" = "全选";
+"menu.settings" = "设置…";
+"menu.show_over_fullscreen" = "显示在全屏应用上方";
+"menu.smaller_text" = "缩小文本";
+"menu.text_size" = "文本大小";
+"menu.undo" = "撤销";
+
+"note.edited" = "编辑于 %@";
+"note.empty" = "空白便笺";
+"note.find_placeholder" = "在便笺中查找";
+"note.new_tab" = "新建便笺";
+"note.not_saved" = "尚未保存";
+"note.saved" = "已保存 · %@";
+"note.untitled" = "新便笺";
+"notes.count" = "%ld 篇便笺";
+"notes.more" = "另外 %ld 篇便笺";
+
+"settings.deck.caption" = "设置便笺在屏幕边缘的显示方式。";
+"settings.deck.detection_area" = "感应区域";
+"settings.deck.detection_help" = "指针距边缘 %ld 点时唤醒便笺栏。";
+"settings.deck.display" = "显示器";
+"settings.deck.drag_help" = "按住 ⌥ Option 并拖移胶囊，可将它移到任意显示器、边缘或高度。";
+"settings.deck.edge" = "边缘";
+"settings.deck.hover_open" = "悬停在标签上时打开便笺";
+"settings.deck.hover_open_help" = "指针停在标签上即可打开，无需点按。默认关闭。";
+"settings.deck.hover_preview" = "悬停时显示预览";
+"settings.deck.hover_preview_help" = "将指针悬停在标签上，无需打开即可预览内容。";
+"settings.deck.keep_open" = "保持便笺栏展开";
+"settings.deck.keep_open_help" = "指针移开后，标签及其文字仍显示在边缘，不会折叠成胶囊。";
+"settings.deck.language" = "语言";
+"settings.deck.language_help" = "更改语言后，Noty 会自动重新启动。";
+"settings.deck.size" = "大小";
+"settings.deck.size_help" = "同时缩放标签、标签文字、颜色标记和收起后的胶囊。";
+"settings.deck.style" = "样式";
+"settings.deck.tab" = "便笺栏";
+
+"settings.notes.caption" = "设置便笺中的文字与格式。";
+"settings.notes.font" = "字体";
+"settings.notes.font_size_value" = "%.1f 点";
+"settings.notes.markdown" = "输入时显示 Markdown 样式";
+"settings.notes.markdown_help" = "支持 **粗体**、*斜体*、`代码`、~~删除线~~、# 标题、> 引用和 [链接](url)；按住 ⌘ 点按可打开链接。文本仍以纯文本保存，只改变显示效果。";
+"settings.notes.note_size" = "便笺大小";
+"settings.notes.tab" = "便笺";
+"settings.notes.text_size" = "文本大小";
+
+"settings.shortcuts.caption" = "点按字段并按下按键；按 ⌫ 可清除。";
+"settings.shortcuts.global" = "在任何应用中";
+"settings.shortcuts.hint" = "便笺内快捷键仅在便笺打开时生效，因此可以使用不带修饰键的按键。";
+"settings.shortcuts.in_note" = "在打开的便笺中";
+"settings.shortcuts.tab" = "快捷键";
+
+"settings.updates.automatic" = "自动检查更新";
+"settings.updates.caption" = "Noty 会获取一个文件，用于检查是否有新版本。";
+"settings.updates.check_now" = "现在检查";
+"settings.updates.privacy" = "获取 appcast.xml 是 Noty 唯一的网络请求；无需账户，没有分析统计，也不会有任何便笺内容离开这台 Mac。每个更新都会使用应用内的 EdDSA 公钥进行验证；由其他密钥签名的更新将被拒绝。";
+"settings.updates.tab" = "更新";
+"settings.updates.this_copy" = "当前版本";
+"settings.updates.version" = "Noty %1$@  （内部版本 %2$@）";
+"settings.window_title" = "Noty 设置";
+
+"shortcut.all_notes" = "所有便笺";
+"shortcut.archive_note" = "归档便笺";
+"shortcut.archive_window" = "归档窗口";
+"shortcut.duplicate" = "已被其他快捷键使用";
+"shortcut.new_note" = "新建便笺";
+"shortcut.press_keys" = "请按快捷键…";
+"shortcut.quick_capture" = "快速记录";
+"shortcut.toggle_task" = "切换任务状态";
+
+"size.default" = "默认";
+"size.extra_large" = "特大";
+"size.huge" = "超大";
+"size.large" = "大";
+"size.medium" = "中";
+"size.small" = "小";
+
+"undo.note_deleted" = "便笺已删除";
+
+"updates.install_sparkle" = "请运行 ./scripts/fetch-sparkle.sh 并重新构建，以加入更新程序。";
+"updates.last_checked" = "上次检查于 %@。";
+"updates.no_sparkle_status" = "此构建未包含 Sparkle 框架，因此无法自行更新。";
+"updates.not_checked" = "尚未检查。";
+"updates.unavailable_body" = "此 Noty 构建未包含 Sparkle 框架。请运行 ./scripts/fetch-sparkle.sh 并重新构建，以启用自动更新。";
+"updates.unavailable_title" = "此构建无法使用更新功能";
+
+"welcome.note_body" = "欢迎使用 Noty\n\n便笺停靠在屏幕边缘。将指针移到右侧边缘，便笺栏就会展开。\n\n⌥⌘N  新建便笺\n⌥⌘A  所有便笺\n⌥⌘L  归档\n\n在便笺中：Esc 关闭，⌘F 查找，⌘. 切换颜色，⌘⌫ 删除后可在十秒内撤销。";
+
+"width.narrow" = "窄";
+"width.standard" = "标准";
+"width.very_wide" = "特宽";
+"width.wide" = "宽";

--- a/Resources/zh-Hans.lproj/Localizable.stringsdict
+++ b/Resources/zh-Hans.lproj/Localizable.stringsdict
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>notes.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>%ld 篇便笺</string>
+            <key>other</key>
+            <string>%ld 篇便笺</string>
+        </dict>
+    </dict>
+    <key>notes.more</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>另外 %ld 篇便笺</string>
+            <key>other</key>
+            <string>另外 %ld 篇便笺</string>
+        </dict>
+    </dict>
+    <key>export.choose_folder</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@files@</string>
+        <key>files</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>请选择用于保存 %ld 个 %@ 文件的文件夹。</string>
+            <key>other</key>
+            <string>请选择用于保存 %ld 个 %@ 文件的文件夹。</string>
+        </dict>
+    </dict>
+    <key>import.added</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notes@</string>
+        <key>notes</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>ld</string>
+            <key>one</key>
+            <string>已添加 %ld 篇便笺。</string>
+            <key>other</key>
+            <string>已添加 %ld 篇便笺。</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9,6 +9,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         buildMainMenu()
 
         deckManager = DeckManager()
+        restoreAfterLanguageRelaunch()
         UndoToast.shared.start()
 
         HotKeys.shared.register(
@@ -142,20 +143,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func quit() { NSApp.terminate(nil) }
 
+    /// Bundle localization is fixed for the lifetime of a process. Launch the
+    /// replacement first, then terminate only after Launch Services confirms it.
+    /// On failure the preference is rolled back and the picker re-synced, so the
+    /// window does not sit there claiming a language the running UI never uses.
+    func relaunchForLanguageChange(previous: AppLanguage) {
+        guard !isRelaunching else { return }
+        isRelaunching = true
+
+        // Hand the new instance everything worth putting back: the expanded
+        // note (one per screen is impossible, only one deck is ever expanded)
+        // and, most importantly, the settings window the user is standing in.
+        let expanded = deckManager.decks.values.first { $0.model.state.expandedID != nil }
+        let resume = ReloadResume(
+            noteID: expanded?.model.state.expandedID,
+            displayID: expanded?.displayID,
+            settingsOpen: SettingsWindow.shared.isOpen)
+        if resume.open { ReloadResume.save(resume) }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: Bundle.main.bundleURL,
+                                           configuration: configuration) { _, error in
+            DispatchQueue.main.async {
+                if let error {
+                    NSLog("Noty: language-change relaunch failed — \(error.localizedDescription)")
+                    ReloadResume.clear()
+                    Settings.appLanguage = previous
+                    SettingsWindow.shared.syncPreferences()
+                    self.isRelaunching = false
+                } else {
+                    NSApp.terminate(nil)
+                }
+            }
+        }
+    }
+
+    /// A language-change relaunch through the state the old process handed
+    /// over: reopen the same note on the same display, and the settings window.
+    private func restoreAfterLanguageRelaunch() {
+        guard let resume = ReloadResume.loadAndClear(), resume.open else { return }
+        if let id = resume.noteID, NoteStore.shared.note(id: id) != nil {
+            // Let the freshly launched deck settle into its resting pose before
+            // the note animates in, so it does not fight the restore.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+                let deck = self?.deckManager.decks[resume.displayID ?? 0] ?? self?.deckManager.focused
+                deck?.expand(id)
+            }
+        }
+        if resume.settingsOpen { openSettings() }
+    }
+
+    private var isRelaunching = false
+
     @objc func showAbout() {
         NSApp.activate()
         let a = NSAlert()
         a.messageText = "Noty"
-        a.informativeText = """
-        Sticky notes docked to the edge of your screen.
-
-        ⌥⌘N  new note      ⌥⌘A  all notes      ⌥⌘L  archive
-        In a note — Esc closes, ⌘F finds, ⌘. cycles colour, ⌘⌫ deletes.
-
-        Notes are stored locally in an SQLite database; bodies are encrypted \
-        with AES-GCM. Your notes never leave this Mac — the only network request \
-        the app makes is the update check, which you can switch off.
-        """
+        a.informativeText = L10n.text("about.body")
         a.runModal()
     }
 
@@ -170,28 +216,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let appItem = NSMenuItem()
         let appMenu = NSMenu()
-        appMenu.addItem(withTitle: "About Noty", action: #selector(showAbout), keyEquivalent: "")
-        appMenu.addItem(withTitle: "Check for Updates…", action: #selector(checkForUpdates), keyEquivalent: "")
+        appMenu.addItem(withTitle: L10n.text("menu.about"), action: #selector(showAbout), keyEquivalent: "")
+        appMenu.addItem(withTitle: L10n.text("menu.check_for_updates"), action: #selector(checkForUpdates), keyEquivalent: "")
         appMenu.addItem(.separator())
-        appMenu.addItem(withTitle: "New Note", action: #selector(newNote), keyEquivalent: "n")
-        appMenu.addItem(withTitle: "All Notes", action: #selector(openAllNotes), keyEquivalent: "a")
-        appMenu.addItem(withTitle: "Archive", action: #selector(openArchive), keyEquivalent: "l")
+        let newNoteItem = appMenu.addItem(withTitle: L10n.text("menu.new_note"), action: #selector(newNote), keyEquivalent: "n")
+        let allNotesItem = appMenu.addItem(withTitle: L10n.text("menu.all_notes"), action: #selector(openAllNotes), keyEquivalent: "a")
+        let archiveItem = appMenu.addItem(withTitle: L10n.text("menu.archive"), action: #selector(openArchive), keyEquivalent: "l")
         appMenu.addItem(.separator())
-        appMenu.addItem(withTitle: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
+        appMenu.addItem(withTitle: L10n.text("menu.settings"), action: #selector(openSettings), keyEquivalent: ",")
         appMenu.addItem(.separator())
-        appMenu.addItem(withTitle: "Import…", action: #selector(importStickies), keyEquivalent: "i")
+        appMenu.addItem(withTitle: L10n.text("menu.import"), action: #selector(importStickies), keyEquivalent: "i")
         appMenu.addItem(.separator())
-        let bigger = appMenu.addItem(withTitle: "Bigger Text", action: #selector(biggerText), keyEquivalent: "+")
+        let bigger = appMenu.addItem(withTitle: L10n.text("menu.bigger_text"), action: #selector(biggerText), keyEquivalent: "+")
         bigger.keyEquivalentModifierMask = [.control]
-        let smaller = appMenu.addItem(withTitle: "Smaller Text", action: #selector(smallerText), keyEquivalent: "-")
+        let smaller = appMenu.addItem(withTitle: L10n.text("menu.smaller_text"), action: #selector(smallerText), keyEquivalent: "-")
         smaller.keyEquivalentModifierMask = [.control]
         appMenu.addItem(.separator())
-        appMenu.addItem(withTitle: "Hide Noty", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
-        appMenu.addItem(withTitle: "Quit Noty", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenu.addItem(withTitle: L10n.text("menu.hide"), action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
+        appMenu.addItem(withTitle: L10n.text("menu.quit"), action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         // The three global shortcuts already carry ⌥; mirror that here so the menu
         // items do not shadow ⌘N / ⌘A / ⌘L inside text fields.
-        for title in ["New Note", "All Notes", "Archive"] {
-            appMenu.item(withTitle: title)?.keyEquivalentModifierMask = [.command, .option]
+        for item in [newNoteItem, allNotesItem, archiveItem] {
+            item.keyEquivalentModifierMask = [.command, .option]
         }
         for item in appMenu.items where item.action != nil
             && item.action != #selector(NSApplication.hide(_:))
@@ -202,15 +248,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         main.addItem(appItem)
 
         let editItem = NSMenuItem()
-        let edit = NSMenu(title: "Edit")
-        edit.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
-        let redo = edit.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        let edit = NSMenu(title: L10n.text("menu.edit"))
+        edit.addItem(withTitle: L10n.text("menu.undo"), action: Selector(("undo:")), keyEquivalent: "z")
+        let redo = edit.addItem(withTitle: L10n.text("menu.redo"), action: Selector(("redo:")), keyEquivalent: "z")
         redo.keyEquivalentModifierMask = [.command, .shift]
         edit.addItem(.separator())
-        edit.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
-        edit.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
-        edit.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
-        edit.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        edit.addItem(withTitle: L10n.text("menu.cut"), action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        edit.addItem(withTitle: L10n.text("menu.copy"), action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        edit.addItem(withTitle: L10n.text("menu.paste"), action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        edit.addItem(withTitle: L10n.text("menu.select_all"), action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
         editItem.submenu = edit
         main.addItem(editItem)
 

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -48,7 +48,7 @@ enum Crypto {
 // MARK: - Palette
 
 struct NoteColor {
-    let name: String
+    let name: String       // stable English archive value
     let paper: Color      // note body background
     let dash: Color       // saturated edge dash / colour bar
     let ink: Color        // text colour on paper
@@ -68,6 +68,10 @@ struct NoteColor {
 
     static func at(_ i: Int) -> NoteColor { all[((i % all.count) + all.count) % all.count] }
 
+    var localizedName: String {
+        L10n.text("color.\(name.lowercased())")
+    }
+
     private static func hex(_ v: UInt32) -> Color {
         Color(.sRGB,
               red:   Double((v >> 16) & 0xFF) / 255,
@@ -81,10 +85,14 @@ struct NoteColor {
 
 /// One entry per face offered for note bodies.
 struct NoteFace {
-    let name: String          // shown in the menu
+    let name: String          // stable face name; localizedName is shown in UI
     let body: String          // PostScript name, "" for the system font
     let tab: String           // heavier cut used on the tab labels
     let bump: CGFloat         // size nudge so faces look the same size as each other
+
+    var localizedName: String {
+        body.isEmpty ? L10n.text("font.system") : name
+    }
 }
 
 enum Ink {
@@ -173,9 +181,9 @@ enum NoteTextDirection: String, Codable, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .automatic:   "Automatic"
-        case .leftToRight: "Left to Right"
-        case .rightToLeft: "Right to Left"
+        case .automatic:   L10n.text("direction.automatic")
+        case .leftToRight: L10n.text("direction.left_to_right")
+        case .rightToLeft: L10n.text("direction.right_to_left")
         }
     }
 
@@ -277,7 +285,7 @@ struct Note: Identifiable, Hashable {
         return clean.count > 60 ? String(clean.prefix(60)) + "…" : clean
     }
 
-    var displayTitle: String { title.isEmpty ? "New note" : title }
+    var displayTitle: String { title.isEmpty ? L10n.text("note.untitled") : title }
 
     /// Completed / total, or nil when the note holds no tasks.
     var taskProgress: (done: Int, total: Int)? {
@@ -363,7 +371,7 @@ enum Fmt {
     }()
 
     static func ago(_ d: Date) -> String {
-        if Date().timeIntervalSince(d) < 60 { return "just now" }
+        if Date().timeIntervalSince(d) < 60 { return L10n.text("date.just_now") }
         return relative.localizedString(for: d, relativeTo: Date())
     }
 }

--- a/Sources/DeckController.swift
+++ b/Sources/DeckController.swift
@@ -515,17 +515,17 @@ final class DeckController: NSObject {
 
     func showContextMenu(at event: NSEvent) {
         let menu = NSMenu()
-        menu.addItem(withTitle: "New Note", action: #selector(AppDelegate.newNote), keyEquivalent: "")
-        menu.addItem(withTitle: "All Notes", action: #selector(AppDelegate.openAllNotes), keyEquivalent: "")
-        menu.addItem(withTitle: "Archive", action: #selector(AppDelegate.openArchive), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.new_note"), action: #selector(AppDelegate.newNote), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.all_notes"), action: #selector(AppDelegate.openAllNotes), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.archive"), action: #selector(AppDelegate.openArchive), keyEquivalent: "")
         menu.addItem(.separator())
 
-        let overFS = NSMenuItem(title: "Show over full-screen apps",
+        let overFS = NSMenuItem(title: L10n.text("menu.show_over_fullscreen"),
                                 action: #selector(AppDelegate.toggleOverFullScreen), keyEquivalent: "")
         overFS.state = Settings.showOverFullScreen ? .on : .off
         menu.addItem(overFS)
 
-        let styleItem = NSMenuItem(title: "Deck style", action: nil, keyEquivalent: "")
+        let styleItem = NSMenuItem(title: L10n.text("menu.deck_style"), action: nil, keyEquivalent: "")
         let styleMenu = NSMenu()
         for s in DeckStyle.allCases {
             let it = NSMenuItem(title: s.title, action: #selector(AppDelegate.setDeckStyle(_:)), keyEquivalent: "")
@@ -536,10 +536,10 @@ final class DeckController: NSObject {
         styleItem.submenu = styleMenu
         menu.addItem(styleItem)
 
-        let fontItem = NSMenuItem(title: "Note font", action: nil, keyEquivalent: "")
+        let fontItem = NSMenuItem(title: L10n.text("menu.note_font"), action: nil, keyEquivalent: "")
         let fontMenu = NSMenu()
         for f in Ink.faces {
-            let it = NSMenuItem(title: f.name, action: #selector(AppDelegate.setNoteFont(_:)),
+            let it = NSMenuItem(title: f.localizedName, action: #selector(AppDelegate.setNoteFont(_:)),
                                 keyEquivalent: "")
             it.representedObject = f.body
             it.state = Ink.face.body == f.body ? .on : .off
@@ -548,10 +548,10 @@ final class DeckController: NSObject {
         fontItem.submenu = fontMenu
         menu.addItem(fontItem)
 
-        let textItem = NSMenuItem(title: "Text size", action: nil, keyEquivalent: "")
+        let textItem = NSMenuItem(title: L10n.text("menu.text_size"), action: nil, keyEquivalent: "")
         let textMenu = NSMenu()
         for entry in Settings.fontSizes {
-            let it = NSMenuItem(title: entry.name, action: #selector(AppDelegate.setFontSize(_:)),
+            let it = NSMenuItem(title: L10n.text(entry.nameKey), action: #selector(AppDelegate.setFontSize(_:)),
                                 keyEquivalent: "")
             it.representedObject = entry.size
             it.state = abs(Settings.noteFontSize - entry.size) < 0.01 ? .on : .off
@@ -560,10 +560,10 @@ final class DeckController: NSObject {
         textItem.submenu = textMenu
         menu.addItem(textItem)
 
-        let sizeItem = NSMenuItem(title: "Deck size", action: nil, keyEquivalent: "")
+        let sizeItem = NSMenuItem(title: L10n.text("menu.deck_size"), action: nil, keyEquivalent: "")
         let sizeMenu = NSMenu()
         for entry in Settings.deckSizes {
-            let it = NSMenuItem(title: entry.name, action: #selector(AppDelegate.setDeckScale(_:)),
+            let it = NSMenuItem(title: L10n.text(entry.nameKey), action: #selector(AppDelegate.setDeckScale(_:)),
                                 keyEquivalent: "")
             it.representedObject = entry.scale
             it.state = abs(Settings.deckScale - entry.scale) < 0.01 ? .on : .off
@@ -572,26 +572,26 @@ final class DeckController: NSObject {
         sizeItem.submenu = sizeMenu
         menu.addItem(sizeItem)
 
-        let keepOpen = NSMenuItem(title: "Keep deck open",
+        let keepOpen = NSMenuItem(title: L10n.text("menu.keep_deck_open"),
                                   action: #selector(AppDelegate.toggleDeckAlwaysShown), keyEquivalent: "")
         keepOpen.state = Settings.deckAlwaysShown ? .on : .off
         menu.addItem(keepOpen)
 
-        let leftEdge = NSMenuItem(title: "Dock deck to left edge",
+        let leftEdge = NSMenuItem(title: L10n.text("menu.dock_left"),
                                   action: #selector(AppDelegate.toggleDeckEdge), keyEquivalent: "")
         leftEdge.state = Settings.deckOnLeftEdge ? .on : .off
         menu.addItem(leftEdge)
 
         if NSScreen.screens.count > 1 {
-            let displayItem = NSMenuItem(title: "Display", action: nil, keyEquivalent: "")
+            let displayItem = NSMenuItem(title: L10n.text("menu.display"), action: nil, keyEquivalent: "")
             let displayMenu = NSMenu()
 
-            let allItem = NSMenuItem(title: "All Displays", action: #selector(AppDelegate.setDisplayTarget(_:)), keyEquivalent: "")
+            let allItem = NSMenuItem(title: L10n.text("display.all"), action: #selector(AppDelegate.setDisplayTarget(_:)), keyEquivalent: "")
             allItem.representedObject = "all"
             allItem.state = Settings.displayTarget == "all" ? .on : .off
             displayMenu.addItem(allItem)
 
-            let mainItem = NSMenuItem(title: "Main Display", action: #selector(AppDelegate.setDisplayTarget(_:)), keyEquivalent: "")
+            let mainItem = NSMenuItem(title: L10n.text("display.main"), action: #selector(AppDelegate.setDisplayTarget(_:)), keyEquivalent: "")
             mainItem.representedObject = "main"
             mainItem.state = Settings.displayTarget == "main" ? .on : .off
             displayMenu.addItem(mainItem)
@@ -601,7 +601,7 @@ final class DeckController: NSObject {
             for screen in NSScreen.screens {
                 guard let id = (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value else { continue }
                 let name = screen.localizedName
-                let title = screen == NSScreen.main ? "\(name) (Main)" : name
+                let title = screen == NSScreen.main ? L10n.format("display.named_main", name) : name
                 let it = NSMenuItem(title: title, action: #selector(AppDelegate.setDisplayTarget(_:)), keyEquivalent: "")
                 it.representedObject = "id:\(id)"
                 it.state = Settings.displayTarget == "id:\(id)" ? .on : .off
@@ -611,39 +611,39 @@ final class DeckController: NSObject {
             menu.addItem(displayItem)
         }
 
-        let updates = NSMenuItem(title: "Check for Updates…",
+        let updates = NSMenuItem(title: L10n.text("menu.check_for_updates"),
                                  action: #selector(AppDelegate.checkForUpdates), keyEquivalent: "")
         menu.addItem(updates)
 
-        let autoUpdate = NSMenuItem(title: "Check automatically",
+        let autoUpdate = NSMenuItem(title: L10n.text("menu.check_automatically"),
                                     action: #selector(AppDelegate.toggleAutoUpdates), keyEquivalent: "")
         autoUpdate.state = Updater.shared.automaticallyChecks ? .on : .off
         autoUpdate.isEnabled = Updater.available
         menu.addItem(autoUpdate)
         menu.addItem(.separator())
 
-        let login = NSMenuItem(title: "Launch at login",
+        let login = NSMenuItem(title: L10n.text("menu.launch_at_login"),
                                action: #selector(AppDelegate.toggleLaunchAtLogin), keyEquivalent: "")
         login.state = Settings.launchAtLogin ? .on : .off
         menu.addItem(login)
         menu.addItem(.separator())
 
-        let exportItem = NSMenuItem(title: "Export", action: nil, keyEquivalent: "")
+        let exportItem = NSMenuItem(title: L10n.text("menu.export"), action: nil, keyEquivalent: "")
         let exportMenu = NSMenu()
-        exportMenu.addItem(withTitle: "Markdown (one file per note)…",
+        exportMenu.addItem(withTitle: L10n.text("export.markdown_per_note"),
                            action: #selector(AppDelegate.exportMarkdown), keyEquivalent: "")
-        exportMenu.addItem(withTitle: "Plain text (one file per note)…",
+        exportMenu.addItem(withTitle: L10n.text("export.plain_per_note"),
                            action: #selector(AppDelegate.exportPlainText), keyEquivalent: "")
-        exportMenu.addItem(withTitle: "Single document…",
+        exportMenu.addItem(withTitle: L10n.text("export.single_document"),
                            action: #selector(AppDelegate.exportSingleFile), keyEquivalent: "")
-        exportMenu.addItem(withTitle: "Sticky archive (.stickies)…",
+        exportMenu.addItem(withTitle: L10n.text("export.sticky_archive"),
                            action: #selector(AppDelegate.exportStickies), keyEquivalent: "")
         exportItem.submenu = exportMenu
         menu.addItem(exportItem)
-        menu.addItem(withTitle: "Import…", action: #selector(AppDelegate.importStickies), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.import"), action: #selector(AppDelegate.importStickies), keyEquivalent: "")
         menu.addItem(.separator())
-        menu.addItem(withTitle: "Settings…", action: #selector(AppDelegate.openSettings), keyEquivalent: "")
-        menu.addItem(withTitle: "Quit Noty", action: #selector(AppDelegate.quit), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.settings"), action: #selector(AppDelegate.openSettings), keyEquivalent: "")
+        menu.addItem(withTitle: L10n.text("menu.quit"), action: #selector(AppDelegate.quit), keyEquivalent: "")
 
         for item in menu.items where item.action != nil {
             item.target = NSApp.delegate

--- a/Sources/DeckPanel.swift
+++ b/Sources/DeckPanel.swift
@@ -10,8 +10,8 @@ enum DeckStyle: String, CaseIterable {
 
     var title: String {
         switch self {
-        case .tabs: return "Labelled tabs"
-        case .compact: return "Colour chips"
+        case .tabs: return L10n.text("deck_style.labelled_tabs")
+        case .compact: return L10n.text("deck_style.colour_chips")
         }
     }
 }

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -632,7 +632,7 @@ struct NotePreviewCard: View {
                         }
                     }
                 } else if note.body.isEmpty || lines.count <= 1 {
-                    Text("Empty note")
+                    Text(L10n.text("note.empty"))
                         .font(.system(size: 10).italic())
                         .foregroundStyle(note.palette.ink.opacity(0.45))
                 }
@@ -676,7 +676,7 @@ struct MoreTab: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(TabPressStyle())
-        .help("\(count) more note\(count == 1 ? "" : "s")")
+        .help(L10n.plural("notes.more", count))
     }
 }
 
@@ -690,7 +690,7 @@ struct EmptyTab: View {
         Button(action: action) {
             ZStack(alignment: .top) {
                 edgeTabShape(onRight: onRight).fill(.ultraThinMaterial)
-                Text("NEW NOTE")
+                Text(L10n.text("note.new_tab").uppercased())
                     .font(Ink.tabFont)
                     .tracking(Ink.tabTracking)
                     .foregroundStyle(.secondary)
@@ -724,7 +724,7 @@ struct PlusButton: View {
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .animation(.easeOut(duration: 0.15), value: hovering)
-        .help("New Note  ⌥⌘N")
+        .help(L10n.text("help.new_note"))
     }
 }
 
@@ -748,7 +748,7 @@ struct CogButton: View {
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .animation(.easeOut(duration: 0.15), value: hovering)
-        .help("Settings  ⌘,")
+        .help(L10n.text("help.settings"))
     }
 }
 
@@ -757,11 +757,11 @@ struct CogButton: View {
 extension View {
     func noteContextMenu(_ note: Note) -> some View {
         contextMenu {
-            Button(note.pinned ? "Unpin" : "Pin") { NoteStore.shared.togglePin(id: note.id) }
-            Button("Archive") { NoteStore.shared.setArchived(id: note.id, true) }
-            Button("Cycle colour  ⌘.") { NoteStore.shared.cycleColor(id: note.id) }
+            Button(note.pinned ? L10n.text("action.unpin") : L10n.text("action.pin")) { NoteStore.shared.togglePin(id: note.id) }
+            Button(L10n.text("action.archive")) { NoteStore.shared.setArchived(id: note.id, true) }
+            Button(L10n.text("help.cycle_colour")) { NoteStore.shared.cycleColor(id: note.id) }
             Divider()
-            Button("Delete") { NoteStore.shared.delete(id: note.id) }
+            Button(L10n.text("action.delete")) { NoteStore.shared.delete(id: note.id) }
         }
     }
 }

--- a/Sources/ExportImport.swift
+++ b/Sources/ExportImport.swift
@@ -46,7 +46,7 @@ enum Transfer {
 
     static func export(_ format: Format, notes: [Note]) {
         guard !notes.isEmpty else {
-            alert("Nothing to export", "There are no notes yet.")
+            alert(L10n.text("export.empty_title"), L10n.text("export.empty_body"))
             return
         }
         NSApp.activate()
@@ -64,8 +64,8 @@ enum Transfer {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
-        panel.prompt = "Export Here"
-        panel.message = "Choose a folder for \(notes.count) \(ext.uppercased()) file\(notes.count == 1 ? "" : "s")."
+        panel.prompt = L10n.text("export.here")
+        panel.message = L10n.plural("export.choose_folder", notes.count, ext.uppercased())
         guard panel.runModal() == .OK, let dir = panel.url else { return }
 
         var used = Set<String>()
@@ -87,34 +87,43 @@ enum Transfer {
         }
         reveal(dir)
         if written < notes.count {
-            alert("Export incomplete", "Wrote \(written) of \(notes.count) notes. See Console for details.")
+            alert(L10n.text("export.incomplete_title"),
+                  L10n.format("export.incomplete_body", written,
+                              L10n.plural("notes.count", notes.count)))
         }
     }
 
     private static func exportSingle(_ notes: [Note]) {
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = "Noty-\(Fmt.fileStamp.string(from: Date())).md"
+        panel.nameFieldStringValue = L10n.format(
+            "export.markdown_filename", Fmt.fileStamp.string(from: Date()))
         panel.allowedContentTypes = [.plainText]
         panel.allowsOtherFileTypes = true
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
         let doc = notes.map { n -> String in
-            """
+            let archiveSuffix = n.archived ? L10n.text("export.metadata_archived_suffix") : ""
+            let metadata = L10n.format(
+                "export.metadata", n.palette.localizedName,
+                Fmt.stamp.string(from: n.created), Fmt.stamp.string(from: n.modified),
+                archiveSuffix)
+            return """
             ## \(n.displayTitle)
-            <!-- \(n.palette.name) · created \(Fmt.stamp.string(from: n.created)) · \
-            modified \(Fmt.stamp.string(from: n.modified))\(n.archived ? " · archived" : "") -->
+            <!-- \(metadata) -->
 
             \(Tasks.toMarkdown(n.body))
             """
         }.joined(separator: "\n\n---\n\n")
 
-        let header = "# Noty export\n\n\(notes.count) notes · \(Fmt.stamp.string(from: Date()))\n\n---\n\n"
+        let header = "# \(L10n.text("export.document_title"))\n\n"
+            + "\(L10n.plural("notes.count", notes.count)) · \(Fmt.stamp.string(from: Date()))\n\n---\n\n"
         write(header + doc, to: url)
     }
 
     private static func exportArchive(_ notes: [Note]) {
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = "Noty-\(Fmt.fileStamp.string(from: Date())).stickies"
+        panel.nameFieldStringValue = L10n.format(
+            "export.archive_filename", Fmt.fileStamp.string(from: Date()))
         panel.allowsOtherFileTypes = true
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
@@ -126,7 +135,7 @@ enum Transfer {
             try enc.encode(archive).write(to: url, options: .atomic)
             reveal(url)
         } catch {
-            alert("Export failed", error.localizedDescription)
+            alert(L10n.text("export.failed_title"), error.localizedDescription)
         }
     }
 
@@ -153,7 +162,7 @@ enum Transfer {
         if let sticky = UTType(filenameExtension: "stickies") { types.append(sticky) }
         panel.allowedContentTypes = types
         panel.allowsOtherFileTypes = true
-        panel.message = "Choose a .stickies archive, or Markdown / text files."
+        panel.message = L10n.text("import.choose_files")
         guard panel.runModal() == .OK else { return }
 
         var incoming: [Note] = []
@@ -184,10 +193,11 @@ enum Transfer {
 
         let added = NoteStore.shared.ingest(incoming)
         if failed.isEmpty {
-            alert("Import complete", "Added \(added) note\(added == 1 ? "" : "s").")
+            alert(L10n.text("import.complete_title"), L10n.plural("import.added", added))
         } else {
-            alert("Import finished with problems",
-                  "Added \(added) note\(added == 1 ? "" : "s"). Could not read: \(failed.joined(separator: ", "))")
+            alert(L10n.text("import.problems_title"),
+                  L10n.format("import.problems_body", L10n.plural("import.added", added),
+                              failed.joined(separator: ", ")))
         }
     }
 
@@ -199,7 +209,9 @@ enum Transfer {
             .joined(separator: "-")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmed = String(cleaned.prefix(80))
-        return trimmed.isEmpty ? "note-\(n.id.prefix(8))" : trimmed
+        return trimmed.isEmpty
+            ? L10n.format("export.default_note_name", String(n.id.prefix(8)))
+            : trimmed
     }
 
     private static func write(_ s: String, to url: URL) {
@@ -207,7 +219,7 @@ enum Transfer {
             try s.write(to: url, atomically: true, encoding: .utf8)
             reveal(url)
         } catch {
-            alert("Export failed", error.localizedDescription)
+            alert(L10n.text("export.failed_title"), error.localizedDescription)
         }
     }
 

--- a/Sources/L10n.swift
+++ b/Sources/L10n.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The single entry point for user-facing copy. Stable identifiers (database
+/// fields, defaults keys, URL routes, archive values, and font names) never pass
+/// through this type.
+enum L10n {
+    static func text(_ key: String, bundle: Bundle = .main) -> String {
+        bundle.localizedString(forKey: key, value: nil, table: "Localizable")
+    }
+
+    static func format(_ key: String, _ arguments: CVarArg...) -> String {
+        String(format: text(key), locale: .current, arguments: arguments)
+    }
+
+    static func plural(_ key: String, _ count: Int, bundle: Bundle = .main) -> String {
+        String(format: text(key, bundle: bundle), locale: locale(for: bundle),
+               arguments: [count])
+    }
+
+    static func plural(_ key: String, _ count: Int, _ value: String,
+                       bundle: Bundle = .main) -> String {
+        String(format: text(key, bundle: bundle), locale: locale(for: bundle),
+               arguments: [count, value])
+    }
+
+    /// Plural rules follow the app language, which can differ from the Mac's
+    /// regional format when the user chooses a per-app language in Settings.
+    private static func locale(for bundle: Bundle) -> Locale {
+        if bundle.bundleURL.pathExtension == "lproj" {
+            return Locale(identifier: bundle.bundleURL.deletingPathExtension().lastPathComponent)
+        }
+        return Locale(identifier: bundle.preferredLocalizations.first
+                      ?? bundle.developmentLocalization
+                      ?? Locale.current.identifier)
+    }
+}

--- a/Sources/LibraryWindow.swift
+++ b/Sources/LibraryWindow.swift
@@ -6,6 +6,13 @@ enum LibraryMode: String, CaseIterable, Identifiable {
     case all = "All Notes"
     case archive = "Archive"
     var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: L10n.text("library.all_notes")
+        case .archive: L10n.text("library.archive")
+        }
+    }
 }
 
 final class LibraryModel: ObservableObject {
@@ -102,7 +109,7 @@ struct LibraryView: View {
     private var sidebar: some View {
         VStack(spacing: 0) {
             Picker("", selection: $model.mode) {
-                ForEach(LibraryMode.allCases) { Text($0.rawValue).tag($0) }
+                ForEach(LibraryMode.allCases) { Text($0.title).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()
@@ -113,7 +120,7 @@ struct LibraryView: View {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 11)).foregroundStyle(.secondary)
-                TextField("Search all notes", text: $model.query)
+                TextField(L10n.text("library.search_placeholder"), text: $model.query)
                     .textFieldStyle(.plain)
                     .font(.system(size: 12))
                 if !model.query.isEmpty {
@@ -133,8 +140,10 @@ struct LibraryView: View {
                     Image(systemName: model.mode == .all ? "note.text" : "archivebox")
                         .font(.system(size: 22)).foregroundStyle(.quaternary)
                     Text(model.query.isEmpty
-                         ? (model.mode == .all ? "No notes yet" : "Nothing archived")
-                         : "No matches")
+                         ? (model.mode == .all
+                            ? L10n.text("library.no_notes")
+                            : L10n.text("library.no_archive"))
+                         : L10n.text("library.no_matches"))
                         .font(.system(size: 12)).foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -149,27 +158,27 @@ struct LibraryView: View {
             Divider()
             HStack(spacing: 12) {
                 Button { NoteStore.shared.create() } label: {
-                    Label("New Note", systemImage: "plus").font(.system(size: 11.5))
+                    Label(L10n.text("menu.new_note"), systemImage: "plus").font(.system(size: 11.5))
                 }
                 .buttonStyle(.plain).foregroundStyle(.secondary)
 
                 Menu {
-                    Button("Markdown — one file per note…") {
+                    Button(L10n.text("export.markdown_per_note")) {
                         Transfer.export(.markdown, notes: NoteStore.shared.notes)
                     }
-                    Button("Plain text — one file per note…") {
+                    Button(L10n.text("export.plain_per_note")) {
                         Transfer.export(.plainText, notes: NoteStore.shared.notes)
                     }
-                    Button("Single document…") {
+                    Button(L10n.text("export.single_document")) {
                         Transfer.export(.singleFile, notes: NoteStore.shared.notes)
                     }
-                    Button("Sticky archive (.stickies)…") {
+                    Button(L10n.text("export.sticky_archive")) {
                         Transfer.export(.stickies, notes: NoteStore.shared.notes)
                     }
                     Divider()
-                    Button("Import…") { Transfer.importFiles() }
+                    Button(L10n.text("menu.import")) { Transfer.importFiles() }
                 } label: {
-                    Label("Export", systemImage: "square.and.arrow.up").font(.system(size: 11.5))
+                    Label(L10n.text("menu.export"), systemImage: "square.and.arrow.up").font(.system(size: 11.5))
                 }
                 .menuStyle(.borderlessButton)
                 .foregroundStyle(.secondary)
@@ -216,12 +225,12 @@ struct LibraryView: View {
         .padding(.vertical, 3)
         .contextMenu {
             if note.archived {
-                Button("Restore") { NoteStore.shared.setArchived(id: note.id, false) }
+                Button(L10n.text("action.restore")) { NoteStore.shared.setArchived(id: note.id, false) }
             } else {
-                Button("Archive") { NoteStore.shared.setArchived(id: note.id, true) }
+                Button(L10n.text("action.archive")) { NoteStore.shared.setArchived(id: note.id, true) }
             }
             Divider()
-            Button("Delete") { NoteStore.shared.delete(id: note.id) }
+            Button(L10n.text("action.delete")) { NoteStore.shared.delete(id: note.id) }
         }
     }
 
@@ -235,7 +244,7 @@ struct LibraryView: View {
         } else {
             VStack(spacing: 8) {
                 Image(systemName: "sidebar.right").font(.system(size: 26)).foregroundStyle(.quaternary)
-                Text("Select a note").font(.system(size: 13)).foregroundStyle(.secondary)
+                Text(L10n.text("library.select_note")).font(.system(size: 13)).foregroundStyle(.secondary)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(nsColor: .textBackgroundColor))
@@ -262,10 +271,10 @@ struct LibraryDetail: View {
                         .padding(3).contentShape(Circle())
                 }
                 .buttonStyle(.plain)
-                .help("Cycle colour · right-click to pick")
+                .help(L10n.text("help.pick_colour"))
                 .contextMenu {
                     ForEach(Array(NoteColor.all.enumerated()), id: \.offset) { idx, c in
-                        Button(idx == note.color ? "✓ \(c.name)" : c.name) {
+                        Button(idx == note.color ? "✓ \(c.localizedName)" : c.localizedName) {
                             NoteStore.shared.setColor(id: note.id, color: idx)
                         }
                     }
@@ -274,7 +283,7 @@ struct LibraryDetail: View {
                 Text(note.displayTitle)
                     .font(.system(size: 13, weight: .semibold)).lineLimit(1)
                 Spacer()
-                Text("Edited \(Fmt.ago(note.modified))")
+                Text(L10n.format("note.edited", Fmt.ago(note.modified)))
                     .font(.system(size: 10.5)).foregroundStyle(.secondary)
 
                 NoteTextDirectionMenu(direction: note.textDirection,
@@ -283,10 +292,10 @@ struct LibraryDetail: View {
                 }
 
                 if note.archived {
-                    Button("Restore") { NoteStore.shared.setArchived(id: note.id, false) }
+                    Button(L10n.text("action.restore")) { NoteStore.shared.setArchived(id: note.id, false) }
                         .controlSize(.small)
                 } else {
-                    Button("Archive") { NoteStore.shared.setArchived(id: note.id, true) }
+                    Button(L10n.text("action.archive")) { NoteStore.shared.setArchived(id: note.id, true) }
                         .controlSize(.small)
                 }
                 Button {

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -528,7 +528,7 @@ struct NoteTextDirectionLabel: View {
                 Image(systemName: symbol)
                     .font(.system(size: 11, weight: .semibold))
             } else {
-                Text("Auto")
+                Text(L10n.text("direction.auto_short"))
                     .font(.system(size: 9.5, weight: .semibold))
             }
         }
@@ -559,7 +559,7 @@ struct NoteTextDirectionMenu: View {
         // overriding the label's foreground style (most visibly for "Auto").
         .tint(foreground)
         .fixedSize()
-        .help("Text direction: \(direction.title)")
+        .help(L10n.format("help.text_direction", direction.title))
     }
 }
 
@@ -654,7 +654,8 @@ struct NoteEditorView: View {
                 .foregroundStyle(pal.ink.opacity(0.92))
                 .lineLimit(1)
             Spacer(minLength: 6)
-            Text(savedAt.map { "Saved · \(Fmt.ago($0))" } ?? "Not saved")
+            Text(savedAt.map { L10n.format("note.saved", Fmt.ago($0)) }
+                 ?? L10n.text("note.not_saved"))
                 .font(.system(size: 10))
                 .foregroundStyle(pal.ink.opacity(0.42))
             Button { NoteStore.shared.togglePin(id: note.id) } label: {
@@ -666,7 +667,7 @@ struct NoteEditorView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(pal.ink.opacity(note.pinned ? 0.85 : 0.4))
-            .help(note.pinned ? "Unpin — ⌘P" : "Pin so it stays open  ⌘P")
+            .help(note.pinned ? L10n.text("help.unpin") : L10n.text("help.pin"))
 
             NoteTextDirectionMenu(direction: note.textDirection,
                                   foreground: pal.ink.opacity(0.5)) {
@@ -681,7 +682,7 @@ struct NoteEditorView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(pal.ink.opacity(0.5))
-            .help("Task  ⌘T")
+            .help(L10n.text("help.task"))
             Button { deck.findQuery = deck.findQuery == nil ? "" : nil } label: {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 10.5, weight: .semibold))
@@ -690,7 +691,7 @@ struct NoteEditorView: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(pal.ink.opacity(0.5))
-            .help("Find  ⌘F")
+            .help(L10n.text("help.find"))
         }
         .padding(.horizontal, 14)
         .frame(height: 32)
@@ -700,7 +701,7 @@ struct NoteEditorView: View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 10)).foregroundStyle(pal.ink.opacity(0.45))
-            TextField("Find in note", text: Binding(
+            TextField(L10n.text("note.find_placeholder"), text: Binding(
                 get: { deck.findQuery ?? "" },
                 set: { deck.findQuery = $0; deck.bridge.recount($0) }))
                 .textFieldStyle(.plain)
@@ -739,18 +740,18 @@ struct NoteEditorView: View {
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
-                .help(c.name)
+                .help(c.localizedName)
             }
             Spacer(minLength: 8)
-            footerButton("Archive") {
+            footerButton(L10n.text("action.archive")) {
                 NoteStore.shared.setArchived(id: note.id, true)
                 controller.collapse()
             }
-            footerButton("Delete") {
+            footerButton(L10n.text("action.delete")) {
                 NoteStore.shared.delete(id: note.id)
                 controller.collapse()
             }
-            footerButton("Close") { controller.collapse() }
+            footerButton(L10n.text("action.close")) { controller.collapse() }
         }
         .padding(.horizontal, 14)
         .frame(height: 34)

--- a/Sources/NoteStore.swift
+++ b/Sources/NoteStore.swift
@@ -159,18 +159,6 @@ final class NoteStore: ObservableObject {
     }
 
     private func seedWelcomeNote() {
-        create(body: """
-        Welcome to Noty
-
-        Your notes live at the edge of the screen. Slide the pointer to the \
-        right edge and the deck fans out.
-
-        ⌥⌘N  new note
-        ⌥⌘A  all notes
-        ⌥⌘L  archive
-
-        Inside a note: Esc closes, ⌘F finds, ⌘. cycles the colour, \
-        ⌘⌫ deletes with ten seconds to undo.
-        """, color: 0)
+        create(body: L10n.text("welcome.note_body"), color: 0)
     }
 }

--- a/Sources/QuickCapture.swift
+++ b/Sources/QuickCapture.swift
@@ -103,7 +103,7 @@ private struct CaptureView: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 7) {
                 Circle().fill(pal.dash).frame(width: 8, height: 8)
-                Text("Quick note")
+                Text(L10n.text("capture.title"))
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(pal.ink.opacity(0.55))
                 Spacer()
@@ -123,7 +123,7 @@ private struct CaptureView: View {
                 }
                 .onKeyPress(.escape) { onCancel(); return .handled }
 
-            Text("↩ save    ⇧↩ new line    esc cancel")
+            Text(L10n.text("capture.hint"))
                 .font(.system(size: 10))
                 .foregroundStyle(pal.ink.opacity(0.4))
         }

--- a/Sources/ReloadState.swift
+++ b/Sources/ReloadState.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// One-shot hand-off between the old and new process on a language-change
+/// relaunch. The new instance reads it at launch and deletes it, so a stale
+/// file can never resurrect old state later.
+struct ReloadResume: Codable {
+    var noteID: String?
+    var displayID: UInt32?
+    var settingsOpen: Bool
+
+    var open: Bool { noteID != nil || settingsOpen }
+
+    static let url = Paths.support.appendingPathComponent("resume.json")
+
+    static func save(_ resume: ReloadResume) {
+        do {
+            try JSONEncoder().encode(resume).write(to: url, options: [.atomic])
+        } catch {
+            NSLog("Noty: could not write reload resume — \(error.localizedDescription)")
+        }
+    }
+
+    static func loadAndClear() -> ReloadResume? {
+        let resume = (try? JSONDecoder().decode(ReloadResume.self, from: Data(contentsOf: url)))
+        try? FileManager.default.removeItem(at: url)
+        return resume
+    }
+
+    static func clear() {
+        try? FileManager.default.removeItem(at: url)
+    }
+}

--- a/Sources/Settings.swift
+++ b/Sources/Settings.swift
@@ -1,9 +1,64 @@
 import Foundation
 import ServiceManagement
 
+/// The language macOS should use for Noty. `system` means there is no
+/// application-specific override, so the normal language preference chain wins.
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system
+    case english = "en"
+    case simplifiedChinese = "zh-Hans"
+
+    var id: String { rawValue }
+
+    var localizedName: String {
+        switch self {
+        case .system:            L10n.text("language.system")
+        case .english:           L10n.text("language.english")
+        case .simplifiedChinese: L10n.text("language.simplified_chinese")
+        }
+    }
+
+    var appleLanguageIdentifier: String? {
+        self == .system ? nil : rawValue
+    }
+
+    static func resolve(_ identifiers: [String]?) -> AppLanguage {
+        guard let identifier = identifiers?.first?.lowercased() else { return .system }
+        if identifier.hasPrefix("en") { return .english }
+        if identifier == "zh" || identifier.hasPrefix("zh-hans")
+            || identifier.hasPrefix("zh-cn") || identifier.hasPrefix("zh-sg") {
+            return .simplifiedChinese
+        }
+        return .system
+    }
+}
+
 /// Thin UserDefaults wrapper for the handful of togglable preferences.
 enum Settings {
     private static let d = UserDefaults.standard
+    private static let applicationDomain = Bundle.main.bundleIdentifier ?? "app.noty.Noty"
+
+    /// Uses the same application-domain preference as macOS System Settings,
+    /// rather than maintaining a second Noty-only language setting.
+    static var appLanguage: AppLanguage {
+        get { appLanguage(in: d, applicationDomain: applicationDomain) }
+        set { setAppLanguage(newValue, in: d) }
+    }
+
+    static func appLanguage(in defaults: UserDefaults,
+                            applicationDomain: String) -> AppLanguage {
+        let identifiers = defaults.persistentDomain(forName: applicationDomain)?["AppleLanguages"]
+            as? [String]
+        return AppLanguage.resolve(identifiers)
+    }
+
+    static func setAppLanguage(_ language: AppLanguage, in defaults: UserDefaults) {
+        if let identifier = language.appleLanguageIdentifier {
+            defaults.set([identifier], forKey: "AppleLanguages")
+        } else {
+            defaults.removeObject(forKey: "AppleLanguages")
+        }
+    }
 
     static var showOverFullScreen: Bool {
         get { d.object(forKey: "showOverFullScreen") as? Bool ?? false }
@@ -42,8 +97,8 @@ enum Settings {
     static let fanLimit = 5
 
     /// Body text size inside a note.
-    static let fontSizes: [(name: String, size: Double)] = [
-        ("Small", 12), ("Medium", 13.5), ("Large", 15.5), ("Extra Large", 18)
+    static let fontSizes: [(nameKey: String, size: Double)] = [
+        ("size.small", 12), ("size.medium", 13.5), ("size.large", 15.5), ("size.extra_large", 18)
     ]
 
     static let fontRange: ClosedRange<Double> = 10...30
@@ -144,8 +199,8 @@ enum Settings {
 
     /// How far from the screen edge the deck notices the pointer. A wider strip
     /// is easier to hit; a narrower one stays further out of the way.
-    static let edgeWidths: [(name: String, width: Double)] = [
-        ("Narrow", 8), ("Standard", 14), ("Wide", 28), ("Very wide", 44)
+    static let edgeWidths: [(nameKey: String, width: Double)] = [
+        ("width.narrow", 8), ("width.standard", 14), ("width.wide", 28), ("width.very_wide", 44)
     ]
 
     static var edgeWidth: Double {
@@ -158,11 +213,11 @@ enum Settings {
 
     // A short list of note sizes. Dragging a corner meant re-laying out a window
     // and a text view on every pointer move; picking from four does it once.
-    static let noteSizes: [(name: String, size: CGSize)] = [
-        ("Small",  CGSize(width: 400, height: 320)),
-        ("Medium", CGSize(width: 460, height: 380)),
-        ("Large",  CGSize(width: 560, height: 470)),
-        ("Huge",   CGSize(width: 680, height: 560)),
+    static let noteSizes: [(nameKey: String, size: CGSize)] = [
+        ("size.small",  CGSize(width: 400, height: 320)),
+        ("size.medium", CGSize(width: 460, height: 380)),
+        ("size.large",  CGSize(width: 560, height: 470)),
+        ("size.huge",   CGSize(width: 680, height: 560)),
     ]
 
     static var noteSizeIndex: Int {
@@ -235,8 +290,8 @@ enum Settings {
     /// instead of drifting out of proportion with itself.
     static let deckScaleRange: ClosedRange<Double> = 0.7...1.8
 
-    static let deckSizes: [(name: String, scale: Double)] = [
-        ("Small", 0.85), ("Default", 1.0), ("Large", 1.25), ("Extra large", 1.5)
+    static let deckSizes: [(nameKey: String, scale: Double)] = [
+        ("size.small", 0.85), ("size.default", 1.0), ("size.large", 1.25), ("size.extra_large", 1.5)
     ]
 
     /// Memoized: DeckGeom routes every metric through this, and SwiftUI reads

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -65,7 +65,7 @@ final class RecorderView: NSView {
         path.lineWidth = recording ? 2 : 1
         path.stroke()
 
-        let text = recording ? "Press keys…" : shortcut.display
+        let text = recording ? L10n.text("shortcut.press_keys") : shortcut.display
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont.systemFont(ofSize: 12, weight: recording ? .regular : .medium),
             .foregroundColor: recording ? NSColor.secondaryLabelColor : NSColor.labelColor,
@@ -98,6 +98,13 @@ struct ShortcutField: NSViewRepresentable {
 // MARK: - Model
 
 final class SettingsModel: ObservableObject {
+    @Published var appLanguage: AppLanguage {
+        didSet {
+            guard !loading, !syncing, appLanguage != oldValue else { return }
+            Settings.appLanguage = appLanguage
+            (NSApp.delegate as? AppDelegate)?.relaunchForLanguageChange(previous: oldValue)
+        }
+    }
     @Published var deckStyle: DeckStyle { didSet { Settings.deckStyle = deckStyle; apply() } }
     @Published var alwaysShown: Bool    { didSet { Settings.deckAlwaysShown = alwaysShown; apply() } }
     @Published var deckScale: Double    { didSet { Settings.deckScale = deckScale; apply() } }
@@ -136,8 +143,12 @@ final class SettingsModel: ObservableObject {
     @Published var scSmaller: Shortcut { didSet { Settings.scSmaller = scSmaller } }
 
     private var loading = true
+    /// True while values are applied back from UserDefaults (e.g. after a
+    /// failed relaunch) — those writes must not re-trigger another relaunch.
+    private var syncing = false
 
     init() {
+        appLanguage = Settings.appLanguage
         deckStyle = Settings.deckStyle
         alwaysShown = Settings.deckAlwaysShown
         deckScale = Settings.deckScale
@@ -177,6 +188,17 @@ final class SettingsModel: ObservableObject {
             }
     }
 
+    /// Re-read a handful of values straight from UserDefaults without firing
+    /// their didSet side-effects — used after a failed language-change relaunch
+    /// to roll the picker back to what the running process actually speaks.
+    func syncFromDefaults() {
+        syncing = true
+        appLanguage = Settings.appLanguage
+        displayTarget = Settings.displayTarget
+        tabPreview = Settings.tabPreview
+        syncing = false
+    }
+
     private func apply() {
         guard !loading else { return }
         (NSApp.delegate as? AppDelegate)?.refreshDecks()
@@ -184,16 +206,16 @@ final class SettingsModel: ObservableObject {
 
     func refreshUpdateStatus() {
         guard Updater.available else {
-            updateStatus = "This build has no Sparkle framework, so it cannot update itself."
+            updateStatus = L10n.text("updates.no_sparkle_status")
             return
         }
         guard let last = Updater.shared.lastCheck else {
-            updateStatus = "No check yet."
+            updateStatus = L10n.text("updates.not_checked")
             return
         }
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .full
-        updateStatus = "Last checked \(f.localizedString(for: last, relativeTo: Date()))."
+        updateStatus = L10n.format("updates.last_checked", f.localizedString(for: last, relativeTo: Date()))
     }
 
     func checkForUpdatesNow() {
@@ -225,9 +247,10 @@ final class SettingsWindow: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private let model = SettingsModel()
 
+    var isOpen: Bool { window?.isVisible ?? false }
+
     func syncPreferences() {
-        model.displayTarget = Settings.displayTarget
-        model.tabPreview = Settings.tabPreview
+        model.syncFromDefaults()
     }
 
     func show() {
@@ -235,7 +258,7 @@ final class SettingsWindow: NSObject, NSWindowDelegate {
             let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 500),
                              styleMask: [.titled, .closable],
                              backing: .buffered, defer: false)
-            w.title = "Noty Settings"
+            w.title = L10n.text("settings.window_title")
             w.isReleasedWhenClosed = false
             w.delegate = self
             w.contentView = NSHostingView(rootView: SettingsView(model: model))
@@ -264,14 +287,14 @@ struct SettingsView: View {
         // note settings compete for the same eye. Tabs are what a Settings window
         // is supposed to be, and they leave somewhere obvious to put updates.
         TabView {
-            pane("Click a field and press the keys; ⌫ clears one.") { shortcutsTab }
-                .tabItem { Label("Shortcuts", systemImage: "command") }
-            pane("How the notes sit on the screen edge.") { deckTab }
-                .tabItem { Label("Deck", systemImage: "menucard") }
-            pane("Type and formatting inside a note.") { notesTab }
-                .tabItem { Label("Notes", systemImage: "textformat") }
-            pane("Noty fetches one file to see whether a newer version exists.") { updatesTab }
-                .tabItem { Label("Updates", systemImage: "arrow.triangle.2.circlepath") }
+            pane(L10n.text("settings.shortcuts.caption")) { shortcutsTab }
+                .tabItem { Label(L10n.text("settings.shortcuts.tab"), systemImage: "command") }
+            pane(L10n.text("settings.deck.caption")) { deckTab }
+                .tabItem { Label(L10n.text("settings.deck.tab"), systemImage: "menucard") }
+            pane(L10n.text("settings.notes.caption")) { notesTab }
+                .tabItem { Label(L10n.text("settings.notes.tab"), systemImage: "textformat") }
+            pane(L10n.text("settings.updates.caption")) { updatesTab }
+                .tabItem { Label(L10n.text("settings.updates.tab"), systemImage: "arrow.triangle.2.circlepath") }
         }
         .padding(14)
         .frame(width: 600, height: 500)
@@ -283,27 +306,27 @@ struct SettingsView: View {
         // what is really a reference table.
         HStack(alignment: .top, spacing: 26) {
             VStack(alignment: .leading, spacing: 7) {
-                subhead("From any app")
-                shortcutRow("New note", model.scNewNote, "new") { model.scNewNote = $0 }
-                shortcutRow("All Notes", model.scAllNotes, "all") { model.scAllNotes = $0 }
-                shortcutRow("Archive window", model.scArchive, "archive") { model.scArchive = $0 }
-            shortcutRow("Quick capture", model.scCapture, "capture") { model.scCapture = $0 }
+                subhead(L10n.text("settings.shortcuts.global"))
+                shortcutRow(L10n.text("shortcut.new_note"), model.scNewNote, "new") { model.scNewNote = $0 }
+                shortcutRow(L10n.text("shortcut.all_notes"), model.scAllNotes, "all") { model.scAllNotes = $0 }
+                shortcutRow(L10n.text("shortcut.archive_window"), model.scArchive, "archive") { model.scArchive = $0 }
+                shortcutRow(L10n.text("shortcut.quick_capture"), model.scCapture, "capture") { model.scCapture = $0 }
                 Spacer(minLength: 0)
             }
             VStack(alignment: .leading, spacing: 7) {
-                subhead("In an open note")
-                shortcutRow("Close", model.scClose, "close", bare: true) { model.scClose = $0 }
-                shortcutRow("Archive note", model.scArchiveNote, "archiveNote", bare: true) { model.scArchiveNote = $0 }
-                shortcutRow("Delete", model.scDelete, "delete", bare: true) { model.scDelete = $0 }
-                shortcutRow("Find", model.scFind, "find", bare: true) { model.scFind = $0 }
-                shortcutRow("Toggle task", model.scTask, "task", bare: true) { model.scTask = $0 }
-                shortcutRow("Pin", model.scPin, "pin", bare: true) { model.scPin = $0 }
-                shortcutRow("Cycle colour", model.scColour, "colour", bare: true) { model.scColour = $0 }
-                shortcutRow("Bigger text", model.scBigger, "bigger", bare: true) { model.scBigger = $0 }
-                shortcutRow("Smaller text", model.scSmaller, "smaller", bare: true) { model.scSmaller = $0 }
+                subhead(L10n.text("settings.shortcuts.in_note"))
+                shortcutRow(L10n.text("action.close"), model.scClose, "close", bare: true) { model.scClose = $0 }
+                shortcutRow(L10n.text("shortcut.archive_note"), model.scArchiveNote, "archiveNote", bare: true) { model.scArchiveNote = $0 }
+                shortcutRow(L10n.text("action.delete"), model.scDelete, "delete", bare: true) { model.scDelete = $0 }
+                shortcutRow(L10n.text("action.find"), model.scFind, "find", bare: true) { model.scFind = $0 }
+                shortcutRow(L10n.text("shortcut.toggle_task"), model.scTask, "task", bare: true) { model.scTask = $0 }
+                shortcutRow(L10n.text("action.pin"), model.scPin, "pin", bare: true) { model.scPin = $0 }
+                shortcutRow(L10n.text("action.cycle_colour"), model.scColour, "colour", bare: true) { model.scColour = $0 }
+                shortcutRow(L10n.text("menu.bigger_text"), model.scBigger, "bigger", bare: true) { model.scBigger = $0 }
+                shortcutRow(L10n.text("menu.smaller_text"), model.scSmaller, "smaller", bare: true) { model.scSmaller = $0 }
             }
         }
-        Text("In-note shortcuts only fire while a note is open, so a key with no modifier is fine there.")
+        Text(L10n.text("settings.shortcuts.hint"))
             .font(.system(size: 11)).foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.top, 2)
@@ -311,12 +334,26 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var deckTab: some View {
-        row("Style") {
+        row(L10n.text("settings.deck.language")) {
+            VStack(alignment: .leading, spacing: 4) {
+                Picker("", selection: $model.appLanguage) {
+                    ForEach(AppLanguage.allCases) { language in
+                        Text(language.localizedName).tag(language)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 220)
+                Text(L10n.text("settings.deck.language_help"))
+                    .font(.system(size: 11)).foregroundStyle(.secondary)
+            }
+        }
+        Divider().padding(.vertical, 2)
+        row(L10n.text("settings.deck.style")) {
             Picker("", selection: $model.deckStyle) {
                 ForEach(DeckStyle.allCases, id: \.self) { Text($0.title).tag($0) }
             }.labelsHidden().pickerStyle(.segmented).frame(width: 240)
         }
-        row("Size") {
+        row(L10n.text("settings.deck.size")) {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 10) {
                     Slider(value: $model.deckScale,
@@ -326,42 +363,42 @@ struct SettingsView: View {
                         .font(.system(size: 11).monospacedDigit())
                         .foregroundStyle(.secondary).frame(width: 52, alignment: .leading)
                 }
-                Text("Scales the tabs, their labels, the chips and the resting pill together.")
+                Text(L10n.text("settings.deck.size_help"))
                     .font(.system(size: 11)).foregroundStyle(.secondary)
             }
         }
         if model.screens.count > 1 {
-            row("Display") {
+            row(L10n.text("settings.deck.display")) {
                 Picker("", selection: $model.displayTarget) {
-                    Text("All Displays").tag("all")
-                    Text("Main Display").tag("main")
+                    Text(L10n.text("display.all")).tag("all")
+                    Text(L10n.text("display.main")).tag("main")
                     ForEach(model.screens, id: \.self) { s in
                         if let id = (s.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value {
                             let name = s.localizedName
-                            let title = s == NSScreen.main ? "\(name) (Main)" : name
+                            let title = s == NSScreen.main ? L10n.format("display.named_main", name) : name
                             Text(title).tag("id:\(id)")
                         }
                     }
                 }.labelsHidden().frame(width: 220)
             }
         }
-        row("Edge") {
+        row(L10n.text("settings.deck.edge")) {
             Picker("", selection: $model.onLeftEdge) {
-                Text("Right").tag(false); Text("Left").tag(true)
+                Text(L10n.text("edge.right")).tag(false); Text(L10n.text("edge.left")).tag(true)
             }.labelsHidden().pickerStyle(.segmented).frame(width: 160)
         }
-        row("Detection area") {
+        row(L10n.text("settings.deck.detection_area")) {
             VStack(alignment: .leading, spacing: 4) {
                 Picker("", selection: $model.edgeWidth) {
-                    ForEach(Settings.edgeWidths, id: \.width) { Text($0.name).tag($0.width) }
+                    ForEach(Settings.edgeWidths, id: \.width) { Text(L10n.text($0.nameKey)).tag($0.width) }
                 }.labelsHidden().pickerStyle(.segmented).frame(width: 300)
-                Text("How far from the edge the pointer wakes the deck — \(Int(model.edgeWidth)) pt.")
+                Text(L10n.format("settings.deck.detection_help", Int(model.edgeWidth)))
                     .font(.system(size: 11)).foregroundStyle(.secondary)
             }
         }
         VStack(alignment: .leading, spacing: 3) {
-            Toggle("Keep the deck open", isOn: $model.alwaysShown)
-            Text("Tabs stay on the edge with their labels showing, instead of folding back into the pill when the pointer leaves.")
+            Toggle(L10n.text("settings.deck.keep_open"), isOn: $model.alwaysShown)
+            Text(L10n.text("settings.deck.keep_open_help"))
                 .font(.system(size: 11)).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -369,51 +406,51 @@ struct SettingsView: View {
         // row disappears rather than sitting there doing nothing.
         if !model.openOnHover {
             VStack(alignment: .leading, spacing: 3) {
-                Toggle("Show preview on hover", isOn: $model.tabPreview)
-                Text("Hover over a tab to peek at its contents without opening it.")
+                Toggle(L10n.text("settings.deck.hover_preview"), isOn: $model.tabPreview)
+                Text(L10n.text("settings.deck.hover_preview_help"))
                     .font(.system(size: 11)).foregroundStyle(.secondary)
             }
         }
         VStack(alignment: .leading, spacing: 3) {
-            Toggle("Open a note by hovering its tab", isOn: $model.openOnHover)
-            Text("Rest on a tab and it opens, no click needed. Off by default.")
+            Toggle(L10n.text("settings.deck.hover_open"), isOn: $model.openOnHover)
+            Text(L10n.text("settings.deck.hover_open_help"))
                 .font(.system(size: 11)).foregroundStyle(.secondary)
         }
-        Toggle("Show over full-screen apps", isOn: $model.overFullScreen)
-        Toggle("Launch at login", isOn: $model.launchAtLogin)
-        Text("Hold ⌥ Option and drag the pill to move it to any screen, edge, or height.")
+        Toggle(L10n.text("menu.show_over_fullscreen"), isOn: $model.overFullScreen)
+        Toggle(L10n.text("menu.launch_at_login"), isOn: $model.launchAtLogin)
+        Text(L10n.text("settings.deck.drag_help"))
             .font(.system(size: 11)).foregroundStyle(.secondary)
             .padding(.top, 2)
     }
 
     @ViewBuilder
     private var notesTab: some View {
-        row("Font") {
+        row(L10n.text("settings.notes.font")) {
             Picker("", selection: $model.fontName) {
-                ForEach(Ink.faces, id: \.body) { Text($0.name).tag($0.body) }
+                ForEach(Ink.faces, id: \.body) { Text($0.localizedName).tag($0.body) }
             }.labelsHidden().frame(width: 200)
         }
-        row("Note size") {
+        row(L10n.text("settings.notes.note_size")) {
             Picker("", selection: $model.noteSizeIndex) {
                 ForEach(Array(Settings.noteSizes.enumerated()), id: \.offset) { i, s in
-                    Text(s.name).tag(i)
+                    Text(L10n.text(s.nameKey)).tag(i)
                 }
             }
             .labelsHidden().pickerStyle(.segmented).frame(width: 300)
         }
-        row("Text size") {
+        row(L10n.text("settings.notes.text_size")) {
             HStack(spacing: 10) {
                 Slider(value: $model.fontSize,
                        in: Settings.fontRange.lowerBound...Settings.fontRange.upperBound,
                        step: 0.5).frame(width: 210)
-                Text("\(model.fontSize, specifier: "%.1f") pt")
+                Text(L10n.format("settings.notes.font_size_value", model.fontSize))
                     .font(.system(size: 11).monospacedDigit())
                     .foregroundStyle(.secondary).frame(width: 52, alignment: .leading)
             }
         }
         VStack(alignment: .leading, spacing: 3) {
-            Toggle("Style Markdown as you type", isOn: $model.markdown)
-            Text("**bold**, *italic*, `code`, ~~struck~~, # headings, > quotes and [links](url), which ⌘-click opens. The text stays plain — only its appearance changes.")
+            Toggle(L10n.text("settings.notes.markdown"), isOn: $model.markdown)
+            Text(L10n.text("settings.notes.markdown_help"))
                 .font(.system(size: 11)).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
@@ -422,30 +459,27 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var updatesTab: some View {
-        row("This copy") {
+        row(L10n.text("settings.updates.this_copy")) {
             Text(Self.versionString)
                 .font(.system(size: 12.5).monospacedDigit())
         }
         VStack(alignment: .leading, spacing: 3) {
-            Toggle("Check for updates automatically", isOn: $model.autoUpdate)
+            Toggle(L10n.text("settings.updates.automatic"), isOn: $model.autoUpdate)
                 .disabled(!Updater.available)
             Text(model.updateStatus)
                 .font(.system(size: 11)).foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
         HStack(spacing: 10) {
-            Button("Check Now") { model.checkForUpdatesNow() }
+            Button(L10n.text("settings.updates.check_now")) { model.checkForUpdatesNow() }
                 .disabled(!Updater.available)
             if !Updater.available {
-                Text("Run ./scripts/fetch-sparkle.sh and rebuild to add the updater.")
+                Text(L10n.text("updates.install_sparkle"))
                     .font(.system(size: 11)).foregroundStyle(.secondary)
             }
         }
         Divider().padding(.vertical, 4)
-        Text("Fetching appcast.xml is the only network request Noty ever makes — "
-             + "no accounts, no analytics, and nothing about a note leaves the Mac. "
-             + "Every update is checked against the EdDSA public key in the app; one "
-             + "signed by any other key is refused.")
+        Text(L10n.text("settings.updates.privacy"))
             .font(.system(size: 11)).foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
         Spacer(minLength: 0)
@@ -455,7 +489,7 @@ struct SettingsView: View {
         let info = Bundle.main.infoDictionary
         let short = info?["CFBundleShortVersionString"] as? String ?? "?"
         let build = info?["CFBundleVersion"] as? String ?? "?"
-        return "Noty \(short)  (build \(build))"
+        return L10n.format("settings.updates.version", short, build)
     }
 
     // MARK: pieces
@@ -502,7 +536,7 @@ struct SettingsView: View {
             if model.duplicate(of: value, ignoring: key) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 10)).foregroundStyle(.orange)
-                    .help("Already used by another shortcut")
+                    .help(L10n.text("shortcut.duplicate"))
             }
             Spacer(minLength: 0)
         }

--- a/Sources/Shortcut.swift
+++ b/Sources/Shortcut.swift
@@ -24,10 +24,10 @@ struct Shortcut: Equatable, Codable {
 
     static func keyName(_ code: UInt32) -> String {
         switch Int(code) {
-        case kVK_Space: return "Space"
+        case kVK_Space: return L10n.text("key.space")
         case kVK_Return: return "↩"
         case kVK_Tab: return "⇥"
-        case kVK_Escape: return "esc"
+        case kVK_Escape: return L10n.text("key.escape")
         case kVK_Delete: return "⌫"
         case kVK_LeftArrow: return "←"
         case kVK_RightArrow: return "→"
@@ -39,7 +39,7 @@ struct Shortcut: Equatable, Codable {
         default: break
         }
         if let s = characters(for: code) { return s.uppercased() }
-        return "key \(code)"
+        return L10n.format("key.unknown", code)
     }
 
     /// Ask the current keyboard layout what an unmodified press produces, so a

--- a/Sources/UndoToast.swift
+++ b/Sources/UndoToast.swift
@@ -63,12 +63,12 @@ struct UndoToastView: View {
             .frame(width: 16, height: 16)
 
             VStack(alignment: .leading, spacing: 1) {
-                Text("Note deleted").font(.system(size: 12, weight: .medium))
+                Text(L10n.text("undo.note_deleted")).font(.system(size: 12, weight: .medium))
                 Text(pending.note.displayTitle)
                     .font(.system(size: 10)).foregroundStyle(.secondary).lineLimit(1)
             }
             Spacer(minLength: 0)
-            Button("Undo") { NoteStore.shared.undoDelete() }
+            Button(L10n.text("action.undo")) { NoteStore.shared.undoDelete() }
                 .buttonStyle(.borderless)
                 .font(.system(size: 12, weight: .semibold))
         }

--- a/Sources/Updater.swift
+++ b/Sources/Updater.swift
@@ -49,9 +49,8 @@ final class Updater {
     func checkForUpdates() {
         NSApp.activate()
         let a = NSAlert()
-        a.messageText = "Updates are not available in this build"
-        a.informativeText = "This copy of Noty was built without the Sparkle framework. "
-            + "Run ./scripts/fetch-sparkle.sh and rebuild to enable automatic updates."
+        a.messageText = L10n.text("updates.unavailable_title")
+        a.informativeText = L10n.text("updates.unavailable_body")
         a.runModal()
     }
 

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -23,6 +23,7 @@ struct EditorStyleEngineTests {
         testTextDirectionConfiguration()
         testLegacyArchiveDefaultsToAutomaticDirection()
         testTextDirectionDatabaseMigration()
+        LocalizationTests.run { check($0, $1) }
 
         guard failures == 0 else {
             fputs("EditorStyleEngineTests: \(failures) failure(s)\n", stderr)

--- a/Tests/LocalizationTests.swift
+++ b/Tests/LocalizationTests.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+enum LocalizationTests {
+    typealias Check = (Bool, String) -> Void
+
+    static func run(check: Check) {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let resources = root.appendingPathComponent("Resources", isDirectory: true)
+        let enURL = resources.appendingPathComponent("en.lproj", isDirectory: true)
+        let zhURL = resources.appendingPathComponent("zh-Hans.lproj", isDirectory: true)
+
+        guard let enStrings = strings(at: enURL.appendingPathComponent("Localizable.strings")),
+              let zhStrings = strings(at: zhURL.appendingPathComponent("Localizable.strings")) else {
+            check(false, "both Localizable.strings files must parse")
+            return
+        }
+
+        check(Set(enStrings.keys) == Set(zhStrings.keys),
+              "English and Simplified Chinese string keys must match")
+        check(enStrings.values.allSatisfy { !$0.isEmpty },
+              "English fallback strings must all be non-empty")
+        for key in Set(enStrings.keys).intersection(zhStrings.keys) {
+            check(placeholders(in: enStrings[key]!) == placeholders(in: zhStrings[key]!),
+                  "format placeholders must match for \(key)")
+        }
+
+        let referenced = sourceKeys(in: root.appendingPathComponent("Sources", isDirectory: true))
+            .union(dynamicKeys)
+        check(referenced.isSubset(of: Set(enStrings.keys)),
+              "every L10n key referenced by source must exist in the English fallback")
+
+        guard let enDict = dictionary(at: enURL.appendingPathComponent("Localizable.stringsdict")),
+              let zhDict = dictionary(at: zhURL.appendingPathComponent("Localizable.stringsdict")) else {
+            check(false, "both Localizable.stringsdict files must parse")
+            return
+        }
+        check(Set(enDict.keys) == Set(zhDict.keys),
+              "English and Simplified Chinese plural keys must match")
+        check(Set(enDict.keys).isSubset(of: Set(enStrings.keys)),
+              "every plural key must have an English fallback string")
+        checkPluralCompatibility(enDict, zhDict, check: check)
+
+        if let enBundle = Bundle(path: enURL.path), let zhBundle = Bundle(path: zhURL.path) {
+            check(L10n.text("menu.new_note", bundle: enBundle) == "New Note",
+                  "English bundle lookup must resolve English")
+            check(L10n.text("menu.new_note", bundle: zhBundle) == "新建便笺",
+                  "Simplified Chinese bundle lookup must resolve Chinese")
+            check(L10n.plural("notes.count", 1, bundle: enBundle) == "1 note",
+                  "English singular rule must resolve")
+            check(L10n.plural("notes.count", 2, bundle: enBundle) == "2 notes",
+                  "English plural rule must resolve")
+            check(L10n.plural("notes.count", 2, bundle: zhBundle) == "2 篇便笺",
+                  "Simplified Chinese plural rule must resolve")
+            check(L10n.plural("export.choose_folder", 1, "MD", bundle: enBundle)
+                  == "Choose a folder for 1 MD file.",
+                  "plural formatting must preserve additional English arguments")
+            check(L10n.plural("export.choose_folder", 2, "MD", bundle: zhBundle)
+                  == "请选择用于保存 2 个 MD 文件的文件夹。",
+                  "plural formatting must preserve additional Chinese arguments")
+        } else {
+            check(false, "language resource directories must load as bundles")
+        }
+
+        let available = ["en", "zh-Hans"]
+        check(Bundle.preferredLocalizations(from: available,
+                                            forPreferences: ["en-US"]).first == "en",
+              "an English system preference must select English")
+        check(Bundle.preferredLocalizations(from: available,
+                                            forPreferences: ["zh-Hans-CN"]).first == "zh-Hans",
+              "a Simplified Chinese system preference must select zh-Hans")
+
+        check(AppLanguage.resolve(nil) == .system
+              && AppLanguage.resolve(["en-GB"]) == .english
+              && AppLanguage.resolve(["zh-Hans-CN"]) == .simplifiedChinese,
+              "application language identifiers must resolve to the supported choices")
+        testLanguagePreference(check: check)
+
+        guard let info = dictionary(at: root.appendingPathComponent("Info.plist")) else {
+            check(false, "Info.plist must parse")
+            return
+        }
+        check(info["CFBundleDevelopmentRegion"] as? String == "en",
+              "Info.plist must declare English as the development language")
+        check(Set(info["CFBundleLocalizations"] as? [String] ?? []) == Set(available),
+              "Info.plist must declare exactly English and Simplified Chinese")
+
+        check(NoteTextDirection.leftToRight.rawValue == "leftToRight"
+              && DeckStyle.tabs.rawValue == "tabs"
+              && LibraryMode.all.rawValue == "All Notes",
+              "localization must not change existing enum raw values")
+        check(StickyNote(Note(color: 0)).colorName == "Lemon",
+              ".stickies colorName must remain the stable English archive value")
+    }
+
+    private static func testLanguagePreference(check: Check) {
+        let suite = "app.noty.localization-tests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            check(false, "an isolated defaults suite must be available")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        Settings.setAppLanguage(.english, in: defaults)
+        check(Settings.appLanguage(in: defaults, applicationDomain: suite) == .english,
+              "English must persist as an application language override")
+        Settings.setAppLanguage(.simplifiedChinese, in: defaults)
+        check(Settings.appLanguage(in: defaults, applicationDomain: suite) == .simplifiedChinese,
+              "Simplified Chinese must persist as an application language override")
+        Settings.setAppLanguage(.system, in: defaults)
+        check(Settings.appLanguage(in: defaults, applicationDomain: suite) == .system,
+              "System Default must remove the application language override")
+    }
+
+    private static let dynamicKeys: Set<String> = [
+        "color.lemon", "color.peach", "color.rose", "color.lilac",
+        "color.sky", "color.mint", "color.sand", "color.slate",
+        "size.small", "size.medium", "size.large", "size.extra_large",
+        "size.huge", "size.default", "width.narrow", "width.standard",
+        "width.wide", "width.very_wide",
+    ]
+
+    private static func strings(at url: URL) -> [String: String]? {
+        guard let value = dictionary(at: url) else { return nil }
+        return value as? [String: String]
+    }
+
+    private static func dictionary(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+              let value = try? PropertyListSerialization.propertyList(from: data,
+                                                                       options: [],
+                                                                       format: nil)
+        else { return nil }
+        return value as? [String: Any]
+    }
+
+    private static func placeholders(in value: String) -> [String] {
+        let pattern = #"%(?:[0-9]+\$)?(?:[-+0 #']*\d*(?:\.\d+)?)?(?:hh|h|ll|l|L|z|j|t|q)?[@diuoxXfFeEgGaAcCsSp]"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = value as NSString
+        return regex.matches(in: value, range: NSRange(location: 0, length: ns.length))
+            .map { ns.substring(with: $0.range) }
+            .sorted()
+    }
+
+    private static func pluralTokens(in value: String) -> [String] {
+        let pattern = #"%(?:[0-9]+\$)?#@[^@]+@"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = value as NSString
+        return regex.matches(in: value, range: NSRange(location: 0, length: ns.length))
+            .map { ns.substring(with: $0.range) }
+            .sorted()
+    }
+
+    private static func sourceKeys(in directory: URL) -> Set<String> {
+        let manager = FileManager.default
+        guard let files = try? manager.contentsOfDirectory(at: directory,
+                                                            includingPropertiesForKeys: nil) else {
+            return []
+        }
+        let pattern = #"L10n\.(?:text|format|plural)\(\s*\"([^\"]+)\""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        var keys = Set<String>()
+        for file in files where file.pathExtension == "swift" {
+            guard let source = try? String(contentsOf: file, encoding: .utf8) else { continue }
+            let ns = source as NSString
+            for match in regex.matches(in: source,
+                                       range: NSRange(location: 0, length: ns.length)) {
+                keys.insert(ns.substring(with: match.range(at: 1)))
+            }
+        }
+        return keys.filter { !$0.contains("\\(") }
+    }
+
+    private static func checkPluralCompatibility(_ en: [String: Any],
+                                                 _ zh: [String: Any],
+                                                 check: Check) {
+        for key in Set(en.keys).intersection(zh.keys) {
+            guard let left = en[key] as? [String: Any],
+                  let right = zh[key] as? [String: Any],
+                  let leftFormat = left["NSStringLocalizedFormatKey"] as? String,
+                  let rightFormat = right["NSStringLocalizedFormatKey"] as? String else {
+                check(false, "plural entry \(key) must have a localized format")
+                continue
+            }
+            check(pluralTokens(in: leftFormat) == pluralTokens(in: rightFormat),
+                  "plural variables must match for \(key)")
+            let leftVariables = Set(left.keys).subtracting(["NSStringLocalizedFormatKey"])
+            let rightVariables = Set(right.keys).subtracting(["NSStringLocalizedFormatKey"])
+            check(leftVariables == rightVariables, "plural variable keys must match for \(key)")
+
+            for variable in leftVariables.intersection(rightVariables) {
+                guard let leftRule = left[variable] as? [String: String],
+                      let rightRule = right[variable] as? [String: String] else {
+                    check(false, "plural rule \(key).\(variable) must parse")
+                    continue
+                }
+                check(leftRule["NSStringFormatSpecTypeKey"] == rightRule["NSStringFormatSpecTypeKey"],
+                      "plural rule type must match for \(key).\(variable)")
+                check(leftRule["NSStringFormatValueTypeKey"] == rightRule["NSStringFormatValueTypeKey"],
+                      "plural value type must match for \(key).\(variable)")
+                let leftCategories = Set(leftRule.keys).subtracting([
+                    "NSStringFormatSpecTypeKey", "NSStringFormatValueTypeKey",
+                ])
+                let rightCategories = Set(rightRule.keys).subtracting([
+                    "NSStringFormatSpecTypeKey", "NSStringFormatValueTypeKey",
+                ])
+                check(leftCategories == rightCategories,
+                      "plural categories must match for \(key).\(variable)")
+                for category in leftCategories.intersection(rightCategories) {
+                    check(placeholders(in: leftRule[category]!) == placeholders(in: rightRule[category]!),
+                          "plural placeholders must match for \(key).\(variable).\(category)")
+                }
+            }
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,9 @@ cp "$ROOT/Info.plist" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $MARKETING_VERSION" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$APP/Contents/Info.plist"
 [ -f "$ROOT/Resources/AppIcon.icns" ] && cp "$ROOT/Resources/AppIcon.icns" "$APP/Contents/Resources/"
+for LOCALIZATION in "$ROOT"/Resources/*.lproj; do
+    [ -d "$LOCALIZATION" ] && cp -R "$LOCALIZATION" "$APP/Contents/Resources/"
+done
 # Sparkle is MIT; redistributing its framework means shipping its notice too.
 [ -f "$ROOT/LICENSE" ] && cp "$ROOT/LICENSE" "$APP/Contents/Resources/LICENSE.txt"
 [ -f "$ROOT/licenses/THIRD-PARTY.txt" ] && cp "$ROOT/licenses/THIRD-PARTY.txt" "$APP/Contents/Resources/"

--- a/scripts/test-editor.sh
+++ b/scripts/test-editor.sh
@@ -16,6 +16,7 @@ swiftc -parse-as-library -swift-version 5 \
     -target arm64-apple-macosx15.0 \
     -sdk "$SDK" \
     "${APP_SOURCES[@]}" \
+    "$ROOT/Tests/LocalizationTests.swift" \
     "$ROOT/Tests/EditorStyleEngineTests.swift" \
     -o "$OUT/EditorStyleEngineTests"
 


### PR DESCRIPTION
## English

### Background

Noty was previously English-only. This PR adds localization support for English and Simplified Chinese, along with an in-app language setting that allows users to switch languages from Settings.

### Changes

- Add an `L10n` helper for localized strings and pluralization using `.stringsdict`
- Add `Localizable.strings` and `Localizable.stringsdict` resources for `en.lproj` and `zh-Hans.lproj`
- Localize UI text, menus, alerts, and Settings
- Add an "App Language" option in Settings and relaunch the app when the language changes
- Restore window and panel state after relaunching for a language change using `ReloadState.swift`
- Update the build script to copy `.lproj` localization resources into the app bundle

### Testing

- Add `LocalizationTests` covering localized strings and plural formatting
- Verify that the Settings window, deck panel, and editor state are restored after switching languages
- Manually test switching between English and Simplified Chinese


---

## 中文

### 背景

Noty 原先仅支持英文界面。本 PR 添加了英文和简体中文的本地化支持，并在设置中加入应用语言选项，允许用户切换界面语言。

### 变更

- 添加 `L10n` 辅助工具，用于本地化字符串以及通过 `.stringsdict` 处理复数形式
- 为 `en.lproj` 和 `zh-Hans.lproj` 添加 `Localizable.strings` 和 `Localizable.stringsdict` 本地化资源
- 本地化界面文本、菜单、提示框和设置页面
- 在设置中添加 “App Language” 选项，并在语言切换后重新启动应用
- 使用 `ReloadState.swift`，在语言切换导致应用重新启动后恢复窗口和面板状态
- 更新构建脚本，将 `.lproj` 本地化资源复制到应用 Bundle 中

### 测试

- 添加 `LocalizationTests`，覆盖本地化字符串和复数格式测试
- 验证切换语言后，设置窗口、Deck 面板和编辑器状态能够正确恢复
- 手动测试英文与简体中文之间的切换流程