### PR TITLE
feat: support independent custom note titles

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -275,6 +275,10 @@ struct Note: Identifiable, Hashable {
 
     var palette: NoteColor { NoteColor.at(color) }
 
+    var hasCustomTitle: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     /// Title shown in the fan / lists, derived from the first non-empty line.
     static func derivedTitle(from body: String) -> String {
         let line = body.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
@@ -285,7 +289,12 @@ struct Note: Identifiable, Hashable {
         return clean.count > 60 ? String(clean.prefix(60)) + "…" : clean
     }
 
-    var displayTitle: String { title.isEmpty ? L10n.text("note.untitled") : title }
+    var displayTitle: String {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        let derived = Self.derivedTitle(from: body)
+        return derived.isEmpty ? L10n.text("note.untitled") : derived
+    }
 
     /// Completed / total, or nil when the note holds no tasks.
     var taskProgress: (done: Int, total: Int)? {

--- a/Sources/L10n.swift
+++ b/Sources/L10n.swift
@@ -4,23 +4,41 @@ import Foundation
 /// fields, defaults keys, URL routes, archive values, and font names) never pass
 /// through this type.
 enum L10n {
-    static func text(_ key: String, bundle: Bundle = .main) -> String {
-        bundle.localizedString(forKey: key, value: nil, table: "Localizable")
+    /// Bundle used for localization lookups. Defaults to .main, but falls back
+    /// to the English resource bundle if running outside a bundled application
+    /// (e.g., during command-line tests).
+    static var fallbackBundle: Bundle = {
+        let bundle = Bundle.main
+        if bundle.path(forResource: "Localizable", ofType: "strings") != nil {
+            return bundle
+        }
+        let devURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources/en.lproj")
+        return Bundle(url: devURL) ?? .main
+    }()
+
+    static func text(_ key: String, bundle: Bundle? = nil) -> String {
+        let b = bundle ?? fallbackBundle
+        return b.localizedString(forKey: key, value: nil, table: "Localizable")
     }
 
     static func format(_ key: String, _ arguments: CVarArg...) -> String {
         String(format: text(key), locale: .current, arguments: arguments)
     }
 
-    static func plural(_ key: String, _ count: Int, bundle: Bundle = .main) -> String {
-        String(format: text(key, bundle: bundle), locale: locale(for: bundle),
-               arguments: [count])
+    static func plural(_ key: String, _ count: Int, bundle: Bundle? = nil) -> String {
+        let b = bundle ?? fallbackBundle
+        return String(format: text(key, bundle: b), locale: locale(for: b),
+                      arguments: [count])
     }
 
     static func plural(_ key: String, _ count: Int, _ value: String,
-                       bundle: Bundle = .main) -> String {
-        String(format: text(key, bundle: bundle), locale: locale(for: bundle),
-               arguments: [count, value])
+                       bundle: Bundle? = nil) -> String {
+        let b = bundle ?? fallbackBundle
+        return String(format: text(key, bundle: b), locale: locale(for: b),
+                      arguments: [count, value])
     }
 
     /// Plural rules follow the app language, which can differ from the Mac's

--- a/Sources/LibraryWindow.swift
+++ b/Sources/LibraryWindow.swift
@@ -75,7 +75,7 @@ struct LibraryView: View {
         let q = model.query.trimmingCharacters(in: .whitespaces).lowercased()
         guard !q.isEmpty else { return source }
         return source.filter {
-            $0.title.lowercased().contains(q) || $0.body.lowercased().contains(q)
+            $0.displayTitle.lowercased().contains(q) || $0.body.lowercased().contains(q)
         }
     }
 
@@ -259,7 +259,9 @@ struct LibraryDetail: View {
     let bridge: EditorBridge
 
     @State private var text = ""
+    @State private var title = ""
     @State private var saveWork: DispatchWorkItem?
+    @State private var titleSaveWork: DispatchWorkItem?
 
     private var pal: NoteColor { note.palette }
 
@@ -280,8 +282,24 @@ struct LibraryDetail: View {
                     }
                 }
 
-                Text(note.displayTitle)
-                    .font(.system(size: 13, weight: .semibold)).lineLimit(1)
+                TextField(
+                    "",
+                    text: $title,
+                    prompt: Text(note.hasCustomTitle ? "Title" : (Note.derivedTitle(from: text).isEmpty ? "New note" : Note.derivedTitle(from: text)))
+                        .foregroundStyle(.secondary)
+                )
+                .textFieldStyle(.plain)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .contextMenu {
+                    if note.hasCustomTitle {
+                        Button("Reset to Auto Title") {
+                            title = ""
+                            NoteStore.shared.updateTitle(id: note.id, title: "")
+                        }
+                    }
+                }
+
                 Spacer()
                 Text(L10n.format("note.edited", Fmt.ago(note.modified)))
                     .font(.system(size: 10.5)).foregroundStyle(.secondary)
@@ -317,16 +335,31 @@ struct LibraryDetail: View {
                          styleToken: "\(note.color)|\(Settings.noteFontSize)|\(Settings.noteFontName)|\(Settings.markdownStyling)")
                 .background(pal.paper)
         }
-        .onAppear { text = note.body }
+        .onAppear {
+            text = note.body
+            title = note.title
+        }
+        .onChange(of: note.id) { _, _ in
+            text = note.body
+            title = note.title
+        }
         .onChange(of: text) { _, v in
             saveWork?.cancel()
             let w = DispatchWorkItem { NoteStore.shared.updateBody(id: note.id, body: v) }
             saveWork = w
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: w)
         }
+        .onChange(of: title) { _, v in
+            titleSaveWork?.cancel()
+            let w = DispatchWorkItem { NoteStore.shared.updateTitle(id: note.id, title: v) }
+            titleSaveWork = w
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: w)
+        }
         .onDisappear {
             saveWork?.cancel()
+            titleSaveWork?.cancel()
             NoteStore.shared.updateBody(id: note.id, body: text)
+            NoteStore.shared.updateTitle(id: note.id, title: title)
         }
     }
 }

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -570,10 +570,13 @@ struct NoteEditorView: View {
     var onRight: Bool = true
 
     @State private var text = ""
+    @State private var title = ""
     @State private var saveWork: DispatchWorkItem?
+    @State private var titleSaveWork: DispatchWorkItem?
     @State private var savedAt: Date?
     @State private var detaching = false
     @FocusState private var findFocused: Bool
+    @FocusState private var titleFocused: Bool
 
     private var pal: NoteColor { note.palette }
 
@@ -593,9 +596,11 @@ struct NoteEditorView: View {
         .overlay(noteShape.strokeBorder(Color.black.opacity(0.07), lineWidth: 0.5))
         .onAppear {
             text = note.body
+            title = note.title
             savedAt = note.modified
         }
         .onChange(of: text) { _, v in scheduleSave(v) }
+        .onChange(of: title) { _, v in scheduleTitleSave(v) }
         .onChange(of: deck.findQuery) { _, q in
             if q != nil { findFocused = true } else { deck.bridge.focusText() }
         }
@@ -672,10 +677,30 @@ struct NoteEditorView: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            Text(note.displayTitle)
-                .font(.system(size: 12.5, weight: .semibold))
-                .foregroundStyle(pal.ink.opacity(0.92))
-                .lineLimit(1)
+            TextField(
+                "",
+                text: $title,
+                prompt: Text(note.hasCustomTitle ? "Title" : (Note.derivedTitle(from: text).isEmpty ? "New note" : Note.derivedTitle(from: text)))
+                    .foregroundStyle(pal.ink.opacity(0.42))
+            )
+            .textFieldStyle(.plain)
+            .font(.system(size: 12.5, weight: .semibold))
+            .foregroundStyle(pal.ink.opacity(0.92))
+            .lineLimit(1)
+            .focused($titleFocused)
+            .onSubmit {
+                flushTitle()
+                deck.bridge.focusText()
+            }
+            .contextMenu {
+                if note.hasCustomTitle {
+                    Button("Reset to Auto Title") {
+                        title = ""
+                        NoteStore.shared.updateTitle(id: note.id, title: "")
+                    }
+                }
+            }
+
             Spacer(minLength: 6)
             Text(savedAt.map { L10n.format("note.saved", Fmt.ago($0)) }
                  ?? L10n.text("note.not_saved"))
@@ -808,8 +833,25 @@ struct NoteEditorView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
     }
 
+    private func scheduleTitleSave(_ value: String) {
+        titleSaveWork?.cancel()
+        let work = DispatchWorkItem {
+            NoteStore.shared.updateTitle(id: note.id, title: value)
+            savedAt = Date()
+        }
+        titleSaveWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: work)
+    }
+
+    private func flushTitle() {
+        titleSaveWork?.cancel()
+        NoteStore.shared.updateTitle(id: note.id, title: title)
+    }
+
     private func flush() {
         saveWork?.cancel()
+        titleSaveWork?.cancel()
         NoteStore.shared.updateBody(id: note.id, body: text)
+        NoteStore.shared.updateTitle(id: note.id, title: title)
     }
 }

--- a/Sources/NoteStore.swift
+++ b/Sources/NoteStore.swift
@@ -33,22 +33,29 @@ final class NoteStore: ObservableObject {
     // MARK: Mutations
 
     @discardableResult
-    func create(body: String = "", color: Int? = nil) -> Note {
+    func create(body: String = "", title: String = "", color: Int? = nil) -> Note {
         var n = Note()
         n.order = (active.map(\.order).min() ?? 0) - 1   // newest sits at the top of the deck
         n.color = color ?? (notes.count % NoteColor.all.count)
         n.body = body
-        n.title = Note.derivedTitle(from: body)
+        n.title = title
         notes.append(n)
         store.upsert(n)
         return n
+    }
+
+    func updateTitle(id: String, title: String) {
+        guard let i = notes.firstIndex(where: { $0.id == id }) else { return }
+        guard notes[i].title != title else { return }
+        notes[i].title = title
+        notes[i].modified = Date()
+        store.upsert(notes[i])
     }
 
     func updateBody(id: String, body: String) {
         guard let i = notes.firstIndex(where: { $0.id == id }) else { return }
         guard notes[i].body != body else { return }
         notes[i].body = body
-        notes[i].title = Note.derivedTitle(from: body)
         notes[i].modified = Date()
         store.upsert(notes[i])
     }

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -24,6 +24,7 @@ struct EditorStyleEngineTests {
         testLegacyArchiveDefaultsToAutomaticDirection()
         testTextDirectionDatabaseMigration()
         LocalizationTests.run { check($0, $1) }
+        testCustomNoteTitleBehavior()
 
         guard failures == 0 else {
             fputs("EditorStyleEngineTests: \(failures) failure(s)\n", stderr)
@@ -530,6 +531,24 @@ struct EditorStyleEngineTests {
               "single-character work in a long note must stay paragraph-local")
         check(processed * 1_000 < text.length,
               "long-note planning must not approach full-document work")
+    }
+
+    private static func testCustomNoteTitleBehavior() {
+        var note = Note()
+        check(note.displayTitle == "New note", "empty note without custom title must display 'New note'")
+        check(!note.hasCustomTitle, "default note should not have custom title")
+
+        note.body = "First line of body\nSecond line"
+        check(note.displayTitle == "First line of body", "note without custom title should derive title from first line")
+
+        note.title = "Explicit Custom Title"
+        check(note.hasCustomTitle, "note with non-empty title should have custom title")
+        check(note.displayTitle == "Explicit Custom Title", "custom title must override derived title")
+
+        // Clearing custom title restores derived title
+        note.title = ""
+        check(!note.hasCustomTitle, "cleared title should not be marked as custom")
+        check(note.displayTitle == "First line of body", "clearing title must restore auto-derived title")
     }
 
     private static func makeTextView(_ source: String) -> NSTextView {


### PR DESCRIPTION
### Summary
Currently, note titles are strictly auto-derived from the first non-empty line
of the note body. Editing the body constantly re-derives the title, making it
impossible to give a note a custom or concise title without prepending a
heading to the content.

This PR adds support for **custom, independent note titles**:
- **Inline Title Editing**: Replaced the static header label with a seamless
`TextField` supporting debounced autosave (`NoteStore.updateTitle`).
- **Dynamic Fallback**: If no custom title is set (or if the title field is
cleared), it smoothly falls back to the auto-derived first line
(`Note.derivedTitle`), and finally to `L10n.text("note.untitled")`.
- **Right-Click Reset**: Added a "Reset to Auto Title" context menu option on
the title field to quickly revert back to derived titles.
- **Library Integration**: Updated `LibraryDetail` with the same title editing
capabilities and improved library search to match against `displayTitle`.
- **Unit Tests**: Added `testCustomNoteTitleBehavior()` covering custom
overrides, clearing behavior, and fallback logic.

Fixes #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes now support editable custom titles in both the editor and library detail pane.
  * Titles can be reset to automatically derive from the note’s first non-empty body line.
  * Note titles are saved automatically while editing.
  * Search now matches displayed titles, including custom and automatically derived titles.

* **Bug Fixes**
  * Improved localization loading reliability across supported app environments.
  * Notes retain custom titles when their body content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->