### PR TITLE
fix: include first body line in preview when custom title is set

### DIFF
--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -309,10 +309,15 @@ struct Note: Identifiable, Hashable {
         return total > 0 ? (done, total) : nil
     }
 
-    /// Second line onwards, collapsed — used as list subtitle.
+    /// Collapsed snippet used as list subtitle.
+    /// If the note has an independent custom title, the first line of the body is
+    /// part of the content and included in the preview; otherwise the first line
+    /// is skipped because it already serves as the title.
     var preview: String {
         let lines = body.split(whereSeparator: \.isNewline).map(String.init)
-        let rest = lines.dropFirst().joined(separator: " ").trimmingCharacters(in: .whitespaces)
+        let rest = (hasCustomTitle ? lines : Array(lines.dropFirst()))
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
         return rest.count > 120 ? String(rest.prefix(120)) + "…" : rest
     }
 }

--- a/Sources/DeckViews.swift
+++ b/Sources/DeckViews.swift
@@ -604,7 +604,7 @@ struct NotePreviewCard: View {
                 }
 
                 let lines = note.body.split(whereSeparator: \.isNewline).map(String.init)
-                let previewLines = Array(lines.dropFirst().prefix(4))
+                let previewLines = Array((note.hasCustomTitle ? lines : Array(lines.dropFirst())).prefix(4))
                 if !previewLines.isEmpty {
                     VStack(alignment: .leading, spacing: 3) {
                         ForEach(Array(previewLines.enumerated()), id: \.offset) { _, line in
@@ -631,7 +631,7 @@ struct NotePreviewCard: View {
                             }
                         }
                     }
-                } else if note.body.isEmpty || lines.count <= 1 {
+                } else {
                     Text(L10n.text("note.empty"))
                         .font(.system(size: 10).italic())
                         .foregroundStyle(note.palette.ink.opacity(0.45))

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -540,15 +540,23 @@ struct EditorStyleEngineTests {
 
         note.body = "First line of body\nSecond line"
         check(note.displayTitle == "First line of body", "note without custom title should derive title from first line")
+        check(note.preview == "Second line", "note without custom title should skip first line in preview")
 
         note.title = "Explicit Custom Title"
         check(note.hasCustomTitle, "note with non-empty title should have custom title")
         check(note.displayTitle == "Explicit Custom Title", "custom title must override derived title")
+        check(note.preview == "First line of body Second line", "note with custom title must include first line in preview")
+
+        // Single-line note with custom title
+        let singleLineNote = Note(title: "Custom Title", body: "Only one line of body")
+        check(singleLineNote.hasCustomTitle, "single-line note should have custom title")
+        check(singleLineNote.preview == "Only one line of body", "single-line note with custom title must show body in preview")
 
         // Clearing custom title restores derived title
         note.title = ""
         check(!note.hasCustomTitle, "cleared title should not be marked as custom")
         check(note.displayTitle == "First line of body", "clearing title must restore auto-derived title")
+        check(note.preview == "Second line", "clearing title must restore preview skipping first line")
     }
 
     private static func makeTextView(_ source: String) -> NSTextView {


### PR DESCRIPTION
### Summary
  When a note has an independent custom title, the first line of the body is
  actual note content rather than a derived title. Previously, `NotePreviewCard`
  and `Note.preview` unconditionally called `lines.dropFirst()`, causing
  single-line notes with custom titles to render `"Empty note"` in hover cards
  and empty subtitles in the library list.
  
  ### Changes
  - **`NotePreviewCard`**: Starts preview from line 1 of the body when
  `note.hasCustomTitle` is true; otherwise drops line 1. Correctly shows `"Empty
  note"` only when no preview lines exist. 
  - **`Note.preview`**: Includes line 1 in the list subtitle preview if the note
  has a custom title.
  - **`EditorStyleEngineTests`**: Added test assertions for single-line notes
  with custom titles and preview extraction behavior.

  Fixes #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Note previews now correctly display the first body line when a custom title is set.
  - Notes without custom titles continue omitting the first line when it serves as the title.
  - Single-line notes with custom titles now show their body content.
  - Preview cards display the appropriate empty-state message when fewer than four preview lines are available.
- **Tests**
  - Added coverage for custom-title preview behavior and restoring default behavior after clearing a custom title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->