### PR TITLE
Sync notes to iPhone and iPad through the iCloud Drive folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ import reads that back. All Notes shows a `done/total` count per note.
   over a full-screen space.
 - **Autosave** 250 ms after you stop typing, and again on close.
 - **Settings** (`⌘,`, the cog under the deck's `+`, or right-click the pill) —
-  four tabs. *Shortcuts* rebinds all twelve. *Deck* covers style, size, which
+  five tabs. *Shortcuts* rebinds all twelve. *Deck* covers style, size, which
   display carries it, the edge, how far from it the pointer wakes the deck, and
   whether the tabs stay out. *Notes* has the face, text size, note size and
-  Markdown. *Updates* shows the version, when it last checked, and checks now.
+  Markdown. *Sync* mirrors notes into iCloud Drive (off by default). *Updates*
+  shows the version, when it last checked, and checks now.
   Everything applies immediately.
 - **Open on hover.** Off by default: turn it on and resting the pointer on a tab
   opens that note without a click.
@@ -181,8 +182,43 @@ import reads that back. All Notes shows a `done/total` count per note.
   a single document, or a `.stickies` archive that preserves colours, archived
   state and dates. **Import** reads `.stickies` back, and will also take loose
   `.md` / `.txt` files.
+- **Sync to iPhone and iPad through iCloud Drive.** Settings → Sync. Each note
+  becomes one Markdown file in iCloud Drive with a small header carrying its
+  colour, dates and identity; open the folder in Files on the phone and edit
+  them in any Markdown editor. Edits travel both ways, new files written on the
+  phone become notes, and deletions propagate. When both sides changed the newer
+  edit wins and the other version is kept in `Noty/Conflicts/`, never discarded.
 - Right-click the pill for the full menu: new note, windows, edge side, launch at
   login, export, import, quit.
+
+### On the phone
+
+Reading needs nothing: tap a file in **Files** and Quick Look renders the
+Markdown. Editing needs an editor that writes **in place**, because sync reads
+the file's own modification date to notice a change. [Taio][taio] is free and a
+good starting point; [Runestone][runestone] (free), [Textastic][textastic] and
+Obsidian (*Open folder as vault* → `iCloud Drive/Noty`) all edit in place too.
+
+Avoid anything that takes a *copy* through an "Open in…" share sheet. Saving
+then leaves a second file carrying the same `noty-id`, which is not what you
+meant and not something Noty can make sense of. Opening the file from the
+editor's own Files browser avoids this.
+
+To write a note on the phone, make an ordinary `.md` file in the `Noty` folder —
+no header, one line of text is enough. The Mac picks it up on its next pass,
+generates an id, writes the header back, and the note joins the deck under the
+filename you chose, titled by its first line. Tasks written as `- [ ]` / `- [x]`
+become `☐` / `☑` on the deck and come back as Markdown. A first line of `---` is
+safe; it is not mistaken for a header.
+
+Two things worth knowing. The sync engine lives in the Mac app, so a file
+written on the phone is picked up when the Mac is running, or next time it
+starts. And `Noty/Conflicts/` is an archive of versions that lost a conflict —
+it is there to be read and pruned by hand, and never syncs back.
+
+[taio]: https://taio.app
+[runestone]: https://runestone.app
+[textastic]: https://www.textasticapp.com
 
 ## Your notes stay on your Mac
 
@@ -195,6 +231,14 @@ import reads that back. All Notes shows a `done/total` count per note.
   newer version exists. Nothing about your notes is sent — it is a plain GET of
   a public XML file. Turn it off with *Check automatically* in the pill's menu,
   and it never fires again.
+- **iCloud sync is off until you switch it on.** With it off, none of the above
+  changes: nothing is written outside `~/Library/Application Support/Noty/`.
+  Switched on (Settings → Sync), Noty mirrors each note into
+  `~/Library/Mobile Documents/com~apple~CloudDocs/Noty/` as a plain Markdown
+  file so it can be read on an iPhone or iPad. **Those files are not encrypted** —
+  they cannot be, or nothing on the phone could open them. The SQLite database on
+  this Mac stays AES-GCM encrypted either way. It uses the iCloud Drive folder
+  macOS already syncs; there is no Noty server, no account and no third party.
 - No Accessibility permission, no Screen Recording, no system permissions.
 
 Verify it yourself:
@@ -307,6 +351,11 @@ Sources/
   NoteEditor.swift      NSTextView bridge, find, 250 ms autosave
   LibraryWindow.swift   All Notes / Archive
   ExportImport.swift    md / txt / single file / .stickies
+  NoteDocument.swift    the front-matter markdown form of a note
+  CloudFolder.swift     the iCloud Drive folder: paths, names, coordinated I/O
+  CloudSyncIndex.swift  what the last sync pass saw
+  SyncPlan.swift        pure decision table: notes + files + index → actions
+  CloudSync.swift       runs the actions, schedules the passes
   UndoToast.swift       the ten-second undo after a delete
 ```
 
@@ -330,6 +379,11 @@ Set `NOTY_DEBUG_DECK=1` in the environment to trace deck state transitions on st
 - **Not sandboxed**, so data lives in `~/Library/Application Support/Noty/`
   rather than `~/Library/Containers/`. Sandboxing needs a provisioning profile,
   which needs Xcode and a developer account.
+- Sync goes through the iCloud Drive **folder**, not CloudKit. CloudKit needs the
+  `com.apple.developer.icloud-container-identifiers` entitlement, which needs a
+  provisioning profile, which needs Xcode and a paid developer account — the same
+  wall that keeps the app unsandboxed. The folder is a plain path any
+  non-sandboxed app may use, and macOS syncs it.
 - The AES key is a `0600` file beside the database. The Keychain is the right
   home for it in a distributed build, but an ad-hoc signature changes on every
   rebuild, which makes the Keychain re-prompt or deny each time.

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -168,6 +168,19 @@
 "settings.shortcuts.in_note" = "In an open note";
 "settings.shortcuts.tab" = "Shortcuts";
 
+"settings.sync.caption" = "Mirror your notes into iCloud Drive so they can be read and edited on iPhone and iPad.";
+"settings.sync.enable" = "Sync notes through iCloud Drive";
+"settings.sync.enable_help" = "Synced notes are written to iCloud Drive as plain Markdown files. They leave the encrypted database — anyone who can reach your iCloud account can read them. The database on this Mac stays encrypted either way.";
+"settings.sync.folder" = "Folder";
+"settings.sync.reveal" = "Show in Finder";
+"settings.sync.status" = "Status";
+"settings.sync.status_last" = "Last synced %@";
+"settings.sync.status_never" = "Waiting for the first sync";
+"settings.sync.status_off" = "Off";
+"settings.sync.status_unavailable" = "iCloud Drive is not available";
+"settings.sync.sync_now" = "Sync Now";
+"settings.sync.tab" = "Sync";
+"settings.sync.unavailable_help" = "Sign in to iCloud and turn on iCloud Drive in System Settings.";
 "settings.updates.automatic" = "Check for updates automatically";
 "settings.updates.caption" = "Noty fetches one file to see whether a newer version exists.";
 "settings.updates.check_now" = "Check Now";

--- a/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Resources/zh-Hans.lproj/Localizable.strings
@@ -168,6 +168,19 @@
 "settings.shortcuts.in_note" = "在打开的便笺中";
 "settings.shortcuts.tab" = "快捷键";
 
+"settings.sync.caption" = "将便签镜像到 iCloud 云盘，以便在 iPhone 和 iPad 上阅读与编辑。";
+"settings.sync.enable" = "通过 iCloud 云盘同步便签";
+"settings.sync.enable_help" = "同步的便签会以纯文本 Markdown 文件写入 iCloud 云盘，它们将离开加密数据库——任何能访问你 iCloud 账户的人都能读取。无论是否开启，这台 Mac 上的数据库始终保持加密。";
+"settings.sync.folder" = "文件夹";
+"settings.sync.reveal" = "在访达中显示";
+"settings.sync.status" = "状态";
+"settings.sync.status_last" = "上次同步于 %@";
+"settings.sync.status_never" = "等待首次同步";
+"settings.sync.status_off" = "已关闭";
+"settings.sync.status_unavailable" = "iCloud 云盘不可用";
+"settings.sync.sync_now" = "立即同步";
+"settings.sync.tab" = "同步";
+"settings.sync.unavailable_help" = "请在“系统设置”中登录 iCloud 并开启 iCloud 云盘。";
 "settings.updates.automatic" = "自动检查更新";
 "settings.updates.caption" = "Noty 会获取一个文件，用于检查是否有新版本。";
 "settings.updates.check_now" = "现在检查";

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -24,10 +24,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // was opened, so a user who never right-clicked was never offered an
         // update however long the app ran.
         _ = Updater.shared
+
+        // Off unless the user asked for it; reload() is a no-op when it is off.
+        CloudSync.shared.reload()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         HotKeys.shared.unregisterAll()
+    }
+
+    /// Coming back to the Mac is the likeliest moment for the phone's edits to
+    /// be waiting, and the poll may be up to its full interval away.
+    func applicationDidBecomeActive(_ notification: Notification) {
+        CloudSync.shared.syncNow()
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { false }

--- a/Sources/CloudFolder.swift
+++ b/Sources/CloudFolder.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+/// The iCloud Drive folder Noty mirrors notes into.
+///
+/// This is a plain path, not a ubiquity container: a non-sandboxed app may read
+/// and write it with no iCloud entitlement, and the system's own daemon does the
+/// syncing. CloudKit and ubiquity containers both need an entitlement that needs
+/// a paid developer account — see
+/// docs/superpowers/specs/2026-09-06-icloud-drive-sync.md.
+enum CloudFolder {
+    static let folderName = "Noty"
+    static let fileExtension = "md"
+
+    static var driveRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Mobile Documents/com~apple~CloudDocs",
+                                    isDirectory: true)
+    }
+
+    static var url: URL { driveRoot.appendingPathComponent(folderName, isDirectory: true) }
+
+    /// iCloud Drive only has a root when the user is signed in and Drive is on.
+    /// Every destructive decision in the sync engine is gated on this: with no
+    /// folder, a missing file means nothing at all.
+    static var isAvailable: Bool {
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: driveRoot.path,
+                                                    isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
+
+    @discardableResult
+    static func ensureFolder() -> Bool {
+        guard isAvailable else { return false }
+        do {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            return true
+        } catch {
+            NSLog("Noty cloud: cannot create \(url.path) — \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    // MARK: Names
+
+    /// Identity lives in the front-matter, so a filename is free to follow the
+    /// title around. `avoiding` holds lowercased names already claimed in this
+    /// pass, since the folder is case-insensitive on a stock Mac.
+    static func fileName(for note: Note, avoiding taken: Set<String>) -> String {
+        // Deliberately not `displayTitle`: its empty case is the localized
+        // "Untitled", which would rename every untitled note's file the moment
+        // the app language changed.
+        let source = note.hasCustomTitle ? note.title : Note.derivedTitle(from: note.body)
+        let cleaned = source
+            .components(separatedBy: CharacterSet(charactersIn: "/\\:*?\"<>|\n\r\t"))
+            .joined(separator: "-")
+            .replacingOccurrences(of: "-{2,}", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        var base = String(cleaned.prefix(80))
+        // A leading dot hides the file from Finder and the Files app, which is the
+        // one thing this feature exists to avoid.
+        if base.isEmpty || base.hasPrefix(".") { base = "note-" + note.id.prefix(8) }
+
+        var candidate = "\(base).\(fileExtension)"
+        var suffix = 2
+        while taken.contains(candidate.lowercased()) {
+            candidate = "\(base)-\(suffix).\(fileExtension)"
+            suffix += 1
+        }
+        return candidate
+    }
+
+    /// Conflict copies live in their own subdirectory. A marker inside the
+    /// filename could always be forged by a note title — and was: a note called
+    /// "Refactor (conflict resolution)" filtered itself out of the folder and
+    /// was then deleted as remotely-missing. A directory cannot be forged,
+    /// because `fileName(for:)` never produces a path separator.
+    static let conflictsFolderName = "Conflicts"
+
+    static var conflictsURL: URL {
+        url.appendingPathComponent(conflictsFolderName, isDirectory: true)
+    }
+
+    static func conflictName(for original: String, at date: Date) -> String {
+        let base = (original as NSString).deletingPathExtension
+        return base + " (conflict " + Fmt.fileStamp.string(from: date) + ").\(fileExtension)"
+    }
+
+    @discardableResult
+    static func writeConflict(_ text: String, named fileName: String,
+                              in directory: URL = CloudFolder.url) -> Bool {
+        let folder = directory.appendingPathComponent(conflictsFolderName, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        } catch {
+            NSLog("Noty cloud: cannot create the conflicts folder — \(error.localizedDescription)")
+            return false
+        }
+        return write(text, to: folder.appendingPathComponent(conflictName(for: fileName, at: Date())))
+    }
+
+    // MARK: Contents
+
+    /// An evicted iCloud item is stored as `.Shopping.md.icloud` — hidden, and
+    /// with a different extension. A listing that skipped hidden files and kept
+    /// only `.md` never saw it, so eviction was indistinguishable from deletion
+    /// and the note was deleted. Resolve both spellings to one document name.
+    static func resolvedName(of url: URL) -> (name: String, downloaded: Bool)? {
+        let raw = url.lastPathComponent
+        let suffix = "." + fileExtension
+        if raw.hasPrefix("."), raw.hasSuffix(".icloud") {
+            let inner = String(raw.dropFirst().dropLast(".icloud".count))
+            guard inner.lowercased().hasSuffix(suffix) else { return nil }
+            return (inner, false)
+        }
+        guard !raw.hasPrefix("."), raw.lowercased().hasSuffix(suffix) else { return nil }
+        return (raw, true)
+    }
+
+    /// One pass's view of the folder: what could be read, and what is there but
+    /// not readable yet. A placeholder gets a download kicked off so a later
+    /// pass can see it; it is never treated as absent.
+    static func scan(in directory: URL = CloudFolder.url) -> FolderScan {
+        guard let items = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsSubdirectoryDescendants]) else { return FolderScan() }
+
+        var out = FolderScan()
+        for url in items.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            guard let resolved = resolvedName(of: url) else { continue }
+            guard resolved.downloaded else {
+                try? FileManager.default.startDownloadingUbiquitousItem(
+                    at: directory.appendingPathComponent(resolved.name))
+                out.unresolved.insert(resolved.name)
+                continue
+            }
+            guard ensureDownloaded(url), let date = modificationDate(of: url) else {
+                out.unresolved.insert(resolved.name)
+                continue
+            }
+            out.documents[resolved.name] = date
+        }
+        return out
+    }
+
+    /// Documents whose contents are here. Kept for the Settings pane and for
+    /// anything that only needs the readable set.
+    static func documentURLs(in directory: URL = CloudFolder.url) -> [URL] {
+        scan(in: directory).documents.keys
+            .sorted()
+            .map { directory.appendingPathComponent($0) }
+    }
+
+    // MARK: I/O
+
+    /// iCloud evicts file contents and leaves a placeholder. Ask for the bytes
+    /// back and report whether they are actually here yet — a caller that gets
+    /// `false` must skip the file this pass rather than treat it as empty.
+    @discardableResult
+    static func ensureDownloaded(_ file: URL) -> Bool {
+        guard let values = try? file.resourceValues(
+                forKeys: [.ubiquitousItemDownloadingStatusKey]),
+              let status = values.ubiquitousItemDownloadingStatus else { return true }
+        if status == .current { return true }
+        try? FileManager.default.startDownloadingUbiquitousItem(at: file)
+        return false
+    }
+
+    static func read(_ file: URL) -> String? {
+        guard ensureDownloaded(file) else { return nil }
+        var text: String?
+        var coordinationError: NSError?
+        NSFileCoordinator().coordinate(readingItemAt: file, options: [],
+                                       error: &coordinationError) { url in
+            text = try? String(contentsOf: url, encoding: .utf8)
+        }
+        if let coordinationError {
+            NSLog("Noty cloud: read \(file.lastPathComponent) — \(coordinationError.localizedDescription)")
+        }
+        return text
+    }
+
+    @discardableResult
+    static func write(_ text: String, to file: URL) -> Bool {
+        var ok = false
+        var coordinationError: NSError?
+        NSFileCoordinator().coordinate(writingItemAt: file, options: .forReplacing,
+                                       error: &coordinationError) { url in
+            do {
+                try text.write(to: url, atomically: true, encoding: .utf8)
+                ok = true
+            } catch {
+                NSLog("Noty cloud: write \(url.lastPathComponent) — \(error.localizedDescription)")
+            }
+        }
+        if let coordinationError {
+            NSLog("Noty cloud: write \(file.lastPathComponent) — \(coordinationError.localizedDescription)")
+        }
+        return ok
+    }
+
+    @discardableResult
+    static func remove(_ file: URL) -> Bool {
+        var ok = false
+        var coordinationError: NSError?
+        NSFileCoordinator().coordinate(writingItemAt: file, options: .forDeleting,
+                                       error: &coordinationError) { url in
+            do {
+                try FileManager.default.removeItem(at: url)
+                ok = true
+            } catch {
+                NSLog("Noty cloud: delete \(url.lastPathComponent) — \(error.localizedDescription)")
+            }
+        }
+        if let coordinationError {
+            NSLog("Noty cloud: delete \(file.lastPathComponent) — \(coordinationError.localizedDescription)")
+        }
+        return ok
+    }
+
+    static func modificationDate(of file: URL) -> Date? {
+        (try? file.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate
+    }
+
+    // MARK: Pass view
+}

--- a/Sources/CloudSync.swift
+++ b/Sources/CloudSync.swift
@@ -1,0 +1,254 @@
+import Combine
+import Foundation
+
+/// Runs sync passes against the iCloud Drive folder.
+///
+/// Main thread only in production. It mutates NoteStore, which every deck,
+/// window and editor observes, and a pass is a few dozen small file reads — a
+/// background queue would cost more in synchronisation than it could save.
+/// (The test binary drives it directly with no run loop, so this is a
+/// convention, not a precondition.)
+final class CloudSync {
+    static let shared = CloudSync(folder: CloudFolderGateway(), store: NoteStore.shared)
+
+    private(set) var lastSync: Date?
+
+    private let folder: SyncFolderGateway
+    private let store: NoteStoring
+    private var index: CloudSyncIndex
+    private let indexURL: URL
+    private var isRunning = false
+    /// Notes parsed during the scan, so performing an action never re-parses a
+    /// document that was already parsed this pass.
+    private var scanned: [String: Note] = [:]
+    /// Lowercased file names already spoken for this pass — everything the
+    /// folder held when the pass began, plus everything written since. Built
+    /// from the index alone, this missed every name on a first sync and let two
+    /// notes overwrite each other.
+    private var claimed: Set<String> = []
+
+    init(folder: SyncFolderGateway, store: NoteStoring,
+         indexURL: URL = CloudSyncIndex.defaultURL) {
+        self.folder = folder
+        self.store = store
+        self.indexURL = indexURL
+        self.index = CloudSyncIndex.load(from: indexURL)
+    }
+
+    /// One pass. Returns false when there was nothing it could do.
+    @discardableResult
+    func syncNow() -> Bool {
+        guard Settings.cloudSyncEnabled, !isRunning else { return false }
+        // Every deletion below is gated on this. With no folder, every file looks
+        // deleted and the pass would empty the deck.
+        guard folder.isAvailable, folder.ensureFolder() else {
+            NSLog("Noty cloud: iCloud Drive is unavailable — skipping this pass")
+            return false
+        }
+
+        isRunning = true
+        defer { isRunning = false; scanned.removeAll(); claimed.removeAll() }
+
+        let scan = folder.scan()
+        claimed = Set(scan.allNames.map { $0.lowercased() })
+        let remote = remoteFiles(from: scan)
+        // A document that was listed but could not be read is still *there*.
+        // Folding it in here is what stops it looking like a deletion.
+        let seen = Set(remote.map(\.fileName))
+        let unresolved = scan.unresolved.union(scan.documents.keys.filter { !seen.contains($0) })
+
+        var changed = false
+        for action in SyncPlan.actions(notes: store.notes, remote: remote,
+                                       unresolved: unresolved, index: index) {
+            perform(action)
+            changed = true
+        }
+        if changed { index.save(to: indexURL) }
+        lastSync = Date()
+        return true
+    }
+
+    /// Builds the planner's view of the folder, reading only what moved. A file
+    /// whose date matches what the index recorded is described from the index,
+    /// which is what keeps a quiet pass down to one directory listing.
+    private func remoteFiles(from scan: FolderScan) -> [SyncPlan.RemoteFile] {
+        var out: [SyncPlan.RemoteFile] = []
+        for (name, fileModified) in scan.documents.sorted(by: { $0.key < $1.key }) {
+            if let id = index.id(forFileName: name),
+               let entry = index.entries[id], entry.fileModified == fileModified {
+                out.append(SyncPlan.RemoteFile(fileName: name, noteID: id,
+                                               declaredModified: entry.syncedModified,
+                                               fileModified: fileModified))
+                continue
+            }
+            guard let text = folder.read(name) else {
+                // Listed a moment ago, unreadable now. Say nothing about it —
+                // `syncNow` folds this name into the unresolved set below.
+                continue
+            }
+            let parsed = NoteDocument.parse(
+                text, fallbackTitle: (name as NSString).deletingPathExtension)
+            scanned[name] = parsed.note
+            out.append(SyncPlan.RemoteFile(
+                fileName: name,
+                noteID: parsed.hasIdentity ? parsed.note.id : nil,
+                declaredModified: parsed.hasIdentity ? parsed.note.modified : .distantPast,
+                fileModified: fileModified))
+        }
+        return out
+    }
+
+    // MARK: Performing
+
+    private func perform(_ action: SyncPlan.Action) {
+        switch action {
+        case .push(let id, let existing):
+            push(noteID: id, existingFileName: existing)
+        case .pull(let name):
+            pull(fileName: name)
+        case .reindex(let id, let name):
+            guard let note = store.note(id: id),
+                  let fileModified = folder.modificationDate(of: name) else { return }
+            index.record(noteID: id, fileName: name,
+                         noteModified: note.modified, fileModified: fileModified)
+        case .adopt(let name):
+            adopt(fileName: name)
+        case .deleteLocal(let id):
+            store.delete(id: id)          // keeps the existing ten-second undo
+            index.forget(noteID: id)
+        case .deleteRemote(let name):
+            folder.remove(name)
+            if let id = index.id(forFileName: name) { index.forget(noteID: id) }
+        case .conflict(let id, let name, let localWins):
+            resolve(noteID: id, fileName: name, localWins: localWins)
+        }
+    }
+
+    private func push(noteID: String, existingFileName: String?) {
+        guard let note = store.note(id: noteID) else { return }
+        let indexed = index.entries[noteID]?.fileName
+
+        let name: String
+        if let existing = existingFileName, existing != indexed {
+            // Renamed on another device. Their name wins — deriving our own here
+            // would recreate the old file beside theirs.
+            name = existing
+        } else {
+            var taken = claimed
+            if let existing = existingFileName { taken.remove(existing.lowercased()) }
+            if let indexed { taken.remove(indexed.lowercased()) }
+            name = CloudFolder.fileName(for: note, avoiding: taken)
+        }
+        claimed.insert(name.lowercased())
+
+        guard folder.write(NoteDocument.render(note), named: name) else { return }
+
+        // Remove the document this pass actually saw, not the one the index
+        // remembers — that is the difference between a rename and a duplicate.
+        if let obsolete = existingFileName ?? indexed, obsolete != name {
+            folder.remove(obsolete)
+            claimed.remove(obsolete.lowercased())
+        }
+        index.record(noteID: noteID, fileName: name,
+                     noteModified: note.modified,
+                     fileModified: folder.modificationDate(of: name) ?? Date())
+    }
+
+    private func pull(fileName: String) {
+        guard var incoming = scanned[fileName],
+              let fileModified = folder.modificationDate(of: fileName) else { return }
+        // A foreign editor leaves the header's date stale, so take the later of
+        // the two or the deck would show a time from before the edit.
+        incoming.modified = max(incoming.modified, fileModified)
+        store.absorb(incoming)
+        index.record(noteID: incoming.id, fileName: fileName,
+                     noteModified: incoming.modified, fileModified: fileModified)
+    }
+
+    private func adopt(fileName: String) {
+        guard var incoming = scanned[fileName],
+              let fileModified = folder.modificationDate(of: fileName) else { return }
+
+        incoming.id = UUID().uuidString
+        incoming.created = fileModified
+        incoming.modified = fileModified
+        incoming.order = (store.active.map(\.order).min() ?? 0) - 1
+        incoming.color = abs(fileName.hashValue) % NoteColor.all.count
+        store.absorb(incoming)
+
+        // Write it back so it carries an identity from now on. Keep the filename
+        // the person chose on their phone.
+        guard folder.write(NoteDocument.render(incoming), named: fileName) else { return }
+        index.record(noteID: incoming.id, fileName: fileName,
+                     noteModified: incoming.modified,
+                     fileModified: folder.modificationDate(of: fileName) ?? fileModified)
+    }
+
+    // MARK: Conflicts
+
+    /// The version that lost, as a plain document with **no** front-matter. With
+    /// no identity it can never sync back and can never become a second note —
+    /// it sits in the folder to be read in the Files app and deleted by hand.
+    static func conflictDocument(for note: Note) -> String {
+        "# " + note.displayTitle + "\n\n" + Tasks.toMarkdown(note.body)
+    }
+
+    private func resolve(noteID: String, fileName: String, localWins: Bool) {
+        guard let remoteNote = scanned[fileName],
+              let localNote = store.note(id: noteID) else { return }
+
+        let loser = localWins ? remoteNote : localNote
+        folder.writeConflict(Self.conflictDocument(for: loser), named: fileName)
+        NSLog("Noty cloud: conflict on \(fileName) — kept a copy in \(CloudFolder.conflictsFolderName)")
+
+        if localWins {
+            push(noteID: noteID, existingFileName: fileName)
+        } else {
+            pull(fileName: fileName)
+        }
+    }
+
+    // MARK: Scheduling
+
+    private var timer: Timer?
+    private var bag = Set<AnyCancellable>()
+    private var pending: DispatchWorkItem?
+
+    /// Start or stop according to the preference. Safe to call repeatedly.
+    func reload() {
+        Settings.cloudSyncEnabled ? start() : stop()
+    }
+
+    private func start() {
+        guard timer == nil else { return }
+        // A note changed here: write it out, but not on every keystroke — the
+        // editor autosaves 250 ms after typing stops and each save republishes.
+        NoteStore.shared.$notes
+            .sink { [weak self] _ in self?.scheduleLocalPush() }
+            .store(in: &bag)
+
+        timer = Timer.scheduledTimer(withTimeInterval: Settings.cloudSyncInterval,
+                                     repeats: true) { [weak self] _ in
+            self?.syncNow()
+        }
+        syncNow()
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        pending?.cancel()
+        pending = nil
+        bag.removeAll()
+    }
+
+    /// `$notes` fires while a pass is applying its own pulls; ignoring those is
+    /// what keeps a sync from feeding itself.
+    private func scheduleLocalPush() {
+        guard !isRunning else { return }
+        pending?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.syncNow() }
+        pending = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: work)
+    }
+}

--- a/Sources/CloudSyncIndex.swift
+++ b/Sources/CloudSyncIndex.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// What the last successful sync pass saw, so the next one can tell a local edit
+/// from a remote one. Kept beside the database in Application Support — never in
+/// the synced folder, where another Mac would fight over it.
+struct CloudSyncIndex: Codable {
+    struct Entry: Codable, Equatable {
+        var fileName: String
+        /// The note's `modified` when it was last written out or read in.
+        var syncedModified: Date
+        /// The file's own modification date at that same moment. This, not the
+        /// header, is what detects an edit made by an editor that knows nothing
+        /// about Noty's front-matter.
+        var fileModified: Date
+    }
+
+    var entries: [String: Entry] = [:]      // keyed by note id
+
+    static var defaultURL: URL { Paths.support.appendingPathComponent("cloud-index.json") }
+
+    static func load(from url: URL = CloudSyncIndex.defaultURL) -> CloudSyncIndex {
+        guard let data = try? Data(contentsOf: url),
+              let index = try? decoder.decode(CloudSyncIndex.self, from: data) else {
+            return CloudSyncIndex()
+        }
+        return index
+    }
+
+    func save(to url: URL = CloudSyncIndex.defaultURL) {
+        do {
+            try Self.encoder.encode(self).write(to: url, options: .atomic)
+        } catch {
+            NSLog("Noty cloud: cannot save the sync index — \(error.localizedDescription)")
+        }
+    }
+
+    func id(forFileName name: String) -> String? {
+        entries.first { $0.value.fileName == name }?.key
+    }
+
+    mutating func record(noteID: String, fileName: String,
+                         noteModified: Date, fileModified: Date) {
+        entries[noteID] = Entry(fileName: fileName,
+                                syncedModified: noteModified,
+                                fileModified: fileModified)
+    }
+
+    mutating func forget(noteID: String) { entries[noteID] = nil }
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+}

--- a/Sources/Core.swift
+++ b/Sources/Core.swift
@@ -345,20 +345,35 @@ enum Tasks {
         return String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
     }
 
-    /// Markdown task syntax in, ☐/☑ out.
-    static func fromMarkdown(_ text: String) -> String {
-        text.replacingOccurrences(of: "^(\\s*)[-*]\\s+\\[[ ]\\]\\s+",
-                                  with: "$1" + openPrefix,
-                                  options: [.regularExpression])
-            .replacingOccurrences(of: "^(\\s*)[-*]\\s+\\[[xX]\\]\\s+",
-                                  with: "$1" + donePrefix,
-                                  options: [.regularExpression])
+    /// `String.replacingOccurrences(options: .regularExpression)` cannot request
+    /// `.anchorsMatchLines`, so `^` there means the start of the whole string and
+    /// only the first task in a document was ever converted. Go through
+    /// NSRegularExpression so every line is anchored.
+    private static func replacingLines(_ pattern: String, in text: String,
+                                       with template: String) -> String {
+        guard let re = try? NSRegularExpression(pattern: pattern,
+                                                options: [.anchorsMatchLines]) else { return text }
+        return re.stringByReplacingMatches(in: text, options: [],
+                                           range: NSRange(text.startIndex..., in: text),
+                                           withTemplate: template)
     }
 
-    /// ☐/☑ out, Markdown task syntax in.
+    /// Markdown task syntax in, ☐/☑ out. `[ \t]` rather than `\s` so a match can
+    /// never swallow the newline and weld two lines together.
+    static func fromMarkdown(_ text: String) -> String {
+        var out = replacingLines("^([ \\t]*)[-*][ \\t]+\\[[ ]\\][ \\t]+", in: text,
+                                 with: "$1" + openPrefix)
+        out = replacingLines("^([ \\t]*)[-*][ \\t]+\\[[xX]\\][ \\t]+", in: out,
+                             with: "$1" + donePrefix)
+        return out
+    }
+
+    /// ☐/☑ out, Markdown task syntax in. Anchored, so a marker used mid-sentence
+    /// stays the character the user typed.
     static func toMarkdown(_ text: String) -> String {
-        text.replacingOccurrences(of: openPrefix, with: "- [ ] ")
-            .replacingOccurrences(of: donePrefix, with: "- [x] ")
+        var out = replacingLines("^([ \\t]*)\(open) ", in: text, with: "$1- [ ] ")
+        out = replacingLines("^([ \\t]*)\(done) ", in: out, with: "$1- [x] ")
+        return out
     }
 }
 

--- a/Sources/NoteDocument.swift
+++ b/Sources/NoteDocument.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// The on-disk form of a note in the sync folder: a Markdown document with a
+/// front-matter header. Pure string work — no file system, no AppKit — so the
+/// format is fully covered by tests.
+///
+/// Identity lives in the header, never in the filename, so renaming a note (or
+/// renaming its file from a phone) never creates a duplicate.
+enum NoteDocument {
+    /// The delimiter line, opening and closing.
+    static let fence = "---"
+
+    /// Stable header key names. These are a file format, not user-facing copy —
+    /// they never pass through L10n and must never be renamed.
+    enum Key {
+        static let id = "noty-id"
+        static let color = "color"
+        static let created = "created"
+        static let modified = "modified"
+        static let archived = "archived"
+        static let pinned = "pinned"
+        static let order = "order"
+        static let direction = "direction"
+        static let title = "title"
+
+        static let all: Set<String> = [id, color, created, modified,
+                                       archived, pinned, order, direction, title]
+    }
+
+    static let stamp: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    static func render(_ note: Note) -> String {
+        var header = [
+            "\(Key.id): \(note.id)",
+            "\(Key.color): \(note.color)",
+            "\(Key.created): \(stamp.string(from: note.created))",
+            "\(Key.modified): \(stamp.string(from: note.modified))",
+            "\(Key.archived): \(note.archived)",
+            "\(Key.pinned): \(note.pinned)",
+            "\(Key.order): \(note.order)",
+            "\(Key.direction): \(note.textDirection.rawValue)",
+        ]
+        // An empty title means "derive it from the first line" — a rule the model
+        // owns. Writing the derived value out would freeze it, exactly the bug
+        // NoteStore.migrateDerivedTitles exists to undo.
+        if note.hasCustomTitle {
+            header.append("\(Key.title): \(singleLine(note.title))")
+        }
+        return fence + "\n"
+            + header.joined(separator: "\n") + "\n"
+            + fence + "\n\n"
+            + Tasks.toMarkdown(note.body)
+    }
+
+    /// A title is one line by construction, but a header cannot survive a stray
+    /// newline, so fold rather than trust.
+    private static func singleLine(_ s: String) -> String {
+        s.split(whereSeparator: \.isNewline)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    struct Parsed {
+        var note: Note
+        /// False when the file carried no `noty-id` — something a person created
+        /// on a phone that Noty has never seen. The caller gives it an id and
+        /// writes the file back with one.
+        var hasIdentity: Bool
+    }
+
+    /// `fallbackTitle` is used only when the file can supply no title at all —
+    /// no header title and no derivable first line. Callers pass the filename.
+    static func parse(_ text: String, fallbackTitle: String) -> Parsed {
+        var note = Note()
+        var hasIdentity = false
+        var body = text
+
+        if let (fields, rest) = splitHeader(text) {
+            body = rest
+            for (key, value) in fields {
+                switch key {
+                case Key.id where !value.isEmpty:
+                    note.id = value
+                    hasIdentity = true
+                case Key.color:     note.color = Int(value) ?? note.color
+                case Key.created:   note.created = stamp.date(from: value) ?? note.created
+                case Key.modified:  note.modified = stamp.date(from: value) ?? note.modified
+                case Key.archived:  note.archived = (value == "true")
+                case Key.pinned:    note.pinned = (value == "true")
+                case Key.order:     note.order = Double(value) ?? note.order
+                case Key.direction: note.textDirection = NoteTextDirection(rawValue: value) ?? .automatic
+                case Key.title:     note.title = value
+                default: break
+                }
+            }
+        }
+
+        note.body = Tasks.fromMarkdown(body)
+        if !note.hasCustomTitle && Note.derivedTitle(from: note.body).isEmpty {
+            note.title = fallbackTitle
+        }
+        return Parsed(note: note, hasIdentity: hasIdentity)
+    }
+
+    /// Header fields and the remaining body, or nil when there is no header.
+    ///
+    /// Strict on purpose. Accepting any leading `---` meant a note that opened
+    /// with a horizontal rule lost everything up to the next rule — and because
+    /// such a file has no identity, `adopt` wrote the truncation straight back.
+    /// A header must be entirely `key: value` lines and must carry at least one
+    /// key Noty itself writes.
+    private static func splitHeader(_ text: String) -> ([(String, String)], String)? {
+        let lines = text.components(separatedBy: "\n")
+        guard lines.first?.trimmingCharacters(in: .whitespaces) == fence else { return nil }
+        // ArraySlice keeps the base indices, so this indexes back into `lines`.
+        guard let close = lines.dropFirst().firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces) == fence
+        }) else { return nil }
+
+        var fields: [(String, String)] = []
+        for line in lines[1..<close] {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            guard let colon = trimmed.firstIndex(of: ":") else { return nil }
+            let key = String(trimmed[trimmed.startIndex..<colon])
+            guard isHeaderKey(key) else { return nil }
+            let value = String(trimmed[trimmed.index(after: colon)...])
+                .trimmingCharacters(in: .whitespaces)
+            fields.append((key, value))
+        }
+        guard fields.contains(where: { Key.all.contains($0.0) }) else { return nil }
+
+        var rest = Array(lines[(close + 1)...])
+        if rest.first?.isEmpty == true { rest.removeFirst() }   // the blank line render writes
+        return (fields, rest.joined(separator: "\n"))
+    }
+
+    private static func isHeaderKey(_ key: String) -> Bool {
+        guard let first = key.first, first.isLetter else { return false }
+        return key.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }
+    }
+}

--- a/Sources/NoteEditor.swift
+++ b/Sources/NoteEditor.swift
@@ -599,6 +599,19 @@ struct NoteEditorView: View {
             title = note.title
             savedAt = note.modified
         }
+        .onChange(of: note.modified) { _, incoming in
+            // A sync pull replaced this note while the editor was open. The
+            // view's own saves stamp `savedAt` at or after the store's
+            // timestamp, so anything strictly newer came from somewhere else —
+            // and without this the next keystroke would write the stale text
+            // back and push it to iCloud.
+            guard incoming > (savedAt ?? .distantPast) else { return }
+            saveWork?.cancel()
+            titleSaveWork?.cancel()
+            text = note.body
+            title = note.title
+            savedAt = incoming
+        }
         .onChange(of: text) { _, v in scheduleSave(v) }
         .onChange(of: title) { _, v in scheduleTitleSave(v) }
         .onChange(of: deck.findQuery) { _, q in

--- a/Sources/NoteStore.swift
+++ b/Sources/NoteStore.swift
@@ -181,6 +181,20 @@ final class NoteStore: ObservableObject {
         return added
     }
 
+    /// Insert or replace a note wholesale, keeping the timestamps it arrives
+    /// with. Sync uses this rather than `ingest`, which renumbers and re-ids its
+    /// input because it is importing strangers — a synced note is the same note,
+    /// carried here from another device.
+    func absorb(_ note: Note) {
+        if let i = notes.firstIndex(where: { $0.id == note.id }) {
+            guard notes[i] != note else { return }
+            notes[i] = note
+        } else {
+            notes.append(note)
+        }
+        store.upsert(note)
+    }
+
     private func seedWelcomeNote() {
         create(body: L10n.text("welcome.note_body"), color: 0)
     }

--- a/Sources/Settings.swift
+++ b/Sources/Settings.swift
@@ -274,6 +274,18 @@ enum Settings {
         set { d.set(newValue, forKey: "markdownStyling") }
     }
 
+    /// Mirror notes into iCloud Drive. Off by default and deliberately so: a
+    /// synced note is written out as plain Markdown, which takes it out of the
+    /// AES-GCM database. Nobody gets that by accident.
+    static var cloudSyncEnabled: Bool {
+        get { d.bool(forKey: "cloudSyncEnabled") }
+        set { d.set(newValue, forKey: "cloudSyncEnabled") }
+    }
+
+    /// How often the sync folder is re-listed. A pass only reads files whose
+    /// modification date moved, so this is a directory listing, not a re-read.
+    static let cloudSyncInterval: TimeInterval = 5
+
     /// How long the deck may sit untouched before it tidies itself away.
     static let fanIdleTimeout: TimeInterval = 4
     static let noteIdleTimeout: TimeInterval = 60

--- a/Sources/SettingsWindow.swift
+++ b/Sources/SettingsWindow.swift
@@ -128,6 +128,16 @@ final class SettingsModel: ObservableObject {
     @Published var openOnHover: Bool    { didSet { Settings.openOnHover = openOnHover; apply() } }
     @Published var tabPreview: Bool     { didSet { Settings.tabPreview = tabPreview; apply() } }
 
+    @Published var cloudSync: Bool {
+        didSet {
+            guard !loading, cloudSync != oldValue else { return }
+            Settings.cloudSyncEnabled = cloudSync
+            CloudSync.shared.reload()
+            refreshSyncStatus()
+        }
+    }
+    @Published var syncStatus: String = ""
+
     @Published var scNewNote: Shortcut  { didSet { Settings.scNewNote = scNewNote; HotKeys.shared.reload() } }
     @Published var scAllNotes: Shortcut { didSet { Settings.scAllNotes = scAllNotes; HotKeys.shared.reload() } }
     @Published var scArchive: Shortcut  { didSet { Settings.scArchive = scArchive; HotKeys.shared.reload() } }
@@ -167,6 +177,7 @@ final class SettingsModel: ObservableObject {
         noteSizeIndex = Settings.noteSizeIndex
         openOnHover = Settings.openOnHover
         tabPreview = Settings.tabPreview
+        cloudSync = Settings.cloudSyncEnabled
         scNewNote = Settings.scNewNote
         scAllNotes = Settings.scAllNotes
         scArchive = Settings.scArchive
@@ -182,6 +193,7 @@ final class SettingsModel: ObservableObject {
         scSmaller = Settings.scSmaller
         loading = false
         refreshUpdateStatus()
+        refreshSyncStatus()
 
         NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
@@ -218,6 +230,32 @@ final class SettingsModel: ObservableObject {
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .full
         updateStatus = L10n.format("updates.last_checked", f.localizedString(for: last, relativeTo: Date()))
+    }
+
+    func refreshSyncStatus() {
+        guard Settings.cloudSyncEnabled else {
+            syncStatus = L10n.text("settings.sync.status_off")
+            return
+        }
+        guard CloudFolder.isAvailable else {
+            syncStatus = L10n.text("settings.sync.status_unavailable")
+            return
+        }
+        guard let last = CloudSync.shared.lastSync else {
+            syncStatus = L10n.text("settings.sync.status_never")
+            return
+        }
+        syncStatus = L10n.format("settings.sync.status_last", Fmt.ago(last))
+    }
+
+    func syncNow() {
+        CloudSync.shared.syncNow()
+        refreshSyncStatus()
+    }
+
+    func revealSyncFolder() {
+        CloudFolder.ensureFolder()
+        NSWorkspace.shared.activateFileViewerSelecting([CloudFolder.url])
     }
 
     func checkForUpdatesNow() {
@@ -295,6 +333,8 @@ struct SettingsView: View {
                 .tabItem { Label(L10n.text("settings.deck.tab"), systemImage: "menucard") }
             pane(L10n.text("settings.notes.caption")) { notesTab }
                 .tabItem { Label(L10n.text("settings.notes.tab"), systemImage: "textformat") }
+            pane(L10n.text("settings.sync.caption")) { syncTab }
+                .tabItem { Label(L10n.text("settings.sync.tab"), systemImage: "icloud") }
             pane(L10n.text("settings.updates.caption")) { updatesTab }
                 .tabItem { Label(L10n.text("settings.updates.tab"), systemImage: "arrow.triangle.2.circlepath") }
         }
@@ -466,6 +506,43 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
+    private var syncTab: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(L10n.text("settings.sync.enable"), isOn: $model.cloudSync)
+                .disabled(!CloudFolder.isAvailable)
+            // The one place a person is told that switching this on takes their
+            // notes out of the encrypted database. It does not get to be subtle.
+            Text(L10n.text("settings.sync.enable_help"))
+                .font(.system(size: 11)).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if !CloudFolder.isAvailable {
+                Text(L10n.text("settings.sync.unavailable_help"))
+                    .font(.system(size: 11)).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        row(L10n.text("settings.sync.status")) {
+            HStack(spacing: 10) {
+                Text(model.syncStatus)
+                    .font(.system(size: 12)).foregroundStyle(.secondary)
+                Button(L10n.text("settings.sync.sync_now")) { model.syncNow() }
+                    .disabled(!model.cloudSync || !CloudFolder.isAvailable)
+            }
+        }
+        row(L10n.text("settings.sync.folder")) {
+            HStack(spacing: 10) {
+                Text(CloudFolder.url.path)
+                    .font(.system(size: 11).monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1).truncationMode(.head)
+                Button(L10n.text("settings.sync.reveal")) { model.revealSyncFolder() }
+                    .disabled(!CloudFolder.isAvailable)
+            }
+        }
+        Spacer(minLength: 0)
+    }
+
+    @ViewBuilder
     private var updatesTab: some View {
         row(L10n.text("settings.updates.this_copy")) {
             Text(Self.versionString)
@@ -516,7 +593,10 @@ struct SettingsView: View {
             .padding(.horizontal, 22)
             .padding(.vertical, 18)
         }
-        .onAppear { model.refreshUpdateStatus() }
+        .onAppear {
+            model.refreshUpdateStatus()
+            model.refreshSyncStatus()
+        }
     }
 
     private func subhead(_ text: String) -> some View {

--- a/Sources/SyncGateway.swift
+++ b/Sources/SyncGateway.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// One pass's view of the sync folder. Listing is cheap and reading is not, so
+/// a scan carries dates only; contents are fetched on demand.
+struct FolderScan: Equatable {
+    /// Documents whose contents are available, and when each last changed.
+    var documents: [String: Date] = [:]
+    /// Documents that exist but whose contents are not here: an iCloud
+    /// placeholder still in the cloud, or a read that failed. The notes behind
+    /// these names must be left strictly alone — absence of contents is not
+    /// evidence of deletion.
+    var unresolved: Set<String> = []
+
+    /// Every name the folder holds, readable or not. Filename allocation has to
+    /// avoid all of them, not only the ones that could be read.
+    var allNames: Set<String> { Set(documents.keys).union(unresolved) }
+}
+
+/// Everything a sync pass needs from the file system, behind a protocol so the
+/// runner can be driven in tests with no iCloud, no home directory and no clock.
+protocol SyncFolderGateway {
+    var isAvailable: Bool { get }
+    @discardableResult func ensureFolder() -> Bool
+    func scan() -> FolderScan
+    func read(_ fileName: String) -> String?
+    func modificationDate(of fileName: String) -> Date?
+    @discardableResult func write(_ text: String, named fileName: String) -> Bool
+    @discardableResult func remove(_ fileName: String) -> Bool
+    /// Conflict copies go somewhere a note filename can never reach.
+    @discardableResult func writeConflict(_ text: String, named fileName: String) -> Bool
+}
+
+/// Everything a sync pass needs from the note store.
+protocol NoteStoring: AnyObject {
+    var notes: [Note] { get }
+    var active: [Note] { get }
+    func note(id: String) -> Note?
+    func absorb(_ note: Note)
+    func delete(id: String)
+}
+
+extension NoteStore: NoteStoring {}
+
+/// The production gateway: the real iCloud Drive folder.
+struct CloudFolderGateway: SyncFolderGateway {
+    var isAvailable: Bool { CloudFolder.isAvailable }
+
+    @discardableResult
+    func ensureFolder() -> Bool { CloudFolder.ensureFolder() }
+
+    func scan() -> FolderScan { CloudFolder.scan() }
+
+    func read(_ fileName: String) -> String? {
+        CloudFolder.read(CloudFolder.url.appendingPathComponent(fileName))
+    }
+
+    func modificationDate(of fileName: String) -> Date? {
+        CloudFolder.modificationDate(of: CloudFolder.url.appendingPathComponent(fileName))
+    }
+
+    @discardableResult
+    func write(_ text: String, named fileName: String) -> Bool {
+        CloudFolder.write(text, to: CloudFolder.url.appendingPathComponent(fileName))
+    }
+
+    @discardableResult
+    func remove(_ fileName: String) -> Bool {
+        CloudFolder.remove(CloudFolder.url.appendingPathComponent(fileName))
+    }
+
+    @discardableResult
+    func writeConflict(_ text: String, named fileName: String) -> Bool {
+        CloudFolder.writeConflict(text, named: fileName)
+    }
+}

--- a/Sources/SyncPlan.swift
+++ b/Sources/SyncPlan.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Decides what one sync pass should do. Deliberately pure — no file system, no
+/// NoteStore, no clock — so the whole decision table is covered by tests and the
+/// runner that performs the actions stays thin enough to read.
+enum SyncPlan {
+
+    /// One document found in the sync folder.
+    struct RemoteFile: Equatable {
+        var fileName: String
+        /// nil when the file carries no `noty-id` header — a note somebody wrote
+        /// from scratch on a phone.
+        var noteID: String?
+        /// The `modified` written in the front-matter. `.distantPast` when there
+        /// is no header to read it from.
+        var declaredModified: Date
+        /// The file's own modification date. An editor that knows nothing about
+        /// the header bumps this and not that, so this is the change *signal*.
+        var fileModified: Date
+
+        /// The best evidence of when the remote side last changed — used to
+        /// decide who wins, where the signal only says that something did.
+        var effectiveModified: Date { max(declaredModified, fileModified) }
+    }
+
+    enum Action: Equatable {
+        /// `existingFileName` is the document the pass actually observed for this
+        /// note, when there was one. Removing the *indexed* name instead left a
+        /// rename made on another device behind as a second file with the same
+        /// identity.
+        case push(noteID: String, existingFileName: String?)
+        case pull(fileName: String)
+        /// The two sides already agree and only the bookkeeping is missing.
+        case reindex(noteID: String, fileName: String)
+        case adopt(fileName: String)
+        case deleteLocal(noteID: String)
+        case deleteRemote(fileName: String)
+        case conflict(noteID: String, fileName: String, localWins: Bool)
+    }
+
+    /// `unresolved` names documents that are in the folder but whose contents
+    /// could not be read this pass — an iCloud placeholder, or a failed read.
+    /// Deletion must follow from evidence that a file is gone, never from the
+    /// absence of its contents.
+    ///
+    /// The caller must also have established that the folder itself exists.
+    /// With no folder every file looks deleted, and this would empty the deck.
+    static func actions(notes: [Note], remote: [RemoteFile],
+                        unresolved: Set<String>, index: CloudSyncIndex) -> [Action] {
+        var out: [Action] = []
+        let localIDs = Set(notes.map(\.id))
+        // Group by identity first. Two documents can claim one `noty-id` —
+        // duplicating a note's file copies its front matter along with its body —
+        // and a last-wins dictionary made one of them vanish from the plan
+        // entirely: never pulled, never pushed, never deleted.
+        var identified: [String: [RemoteFile]] = [:]
+        var adoptions: [String] = []
+        for file in remote {
+            guard let id = file.noteID else {
+                adoptions.append(file.fileName)     // written from scratch elsewhere
+                continue
+            }
+            identified[id, default: []].append(file)
+        }
+
+        var remoteByID: [String: RemoteFile] = [:]
+        for id in identified.keys.sorted() {
+            let files = identified[id] ?? []
+            guard files.count > 1 else {
+                remoteByID[id] = files.first
+                continue
+            }
+            // The document the index already names is this note's home. With no
+            // index entry, the newest wins, with the name as a stable tiebreak.
+            let newest = files.max { a, b in
+                a.effectiveModified == b.effectiveModified
+                    ? a.fileName < b.fileName
+                    : a.effectiveModified < b.effectiveModified
+            }
+            let indexedName = index.entries[id]?.fileName
+            let keeper = files.first { $0.fileName == indexedName } ?? newest ?? files[0]
+            remoteByID[id] = keeper
+            // Copying a note's file means "I want a second note like this one".
+            // `adopt` gives it a fresh identity and writes the header back.
+            adoptions += files.filter { $0.fileName != keeper.fileName }.map(\.fileName)
+        }
+
+        for name in adoptions.sorted() {
+            out.append(.adopt(fileName: name))
+        }
+
+        for note in notes {
+            let known = index.entries[note.id]
+            guard let file = remoteByID[note.id] else {
+                guard let known else {
+                    out.append(.push(noteID: note.id, existingFileName: nil))
+                    continue
+                }
+                // The file is still there; we just cannot see into it yet.
+                guard !unresolved.contains(known.fileName) else { continue }
+                out.append(.deleteLocal(noteID: note.id))
+                continue
+            }
+            // With no index entry both sides look new. When the document
+            // still declares the timestamp the note has, they are the same
+            // version and there is nothing to resolve — a lost index used to
+            // turn every note into a conflict and revert every local copy.
+            if known == nil, note.modified == file.declaredModified {
+                out.append(.reindex(noteID: note.id, fileName: file.fileName))
+                continue
+            }
+            // With no index entry both sides look new; a conflict is the honest
+            // reading, and it preserves whichever version loses.
+            let localChanged = known.map { note.modified > $0.syncedModified } ?? true
+            let remoteChanged = known.map { file.fileModified > $0.fileModified } ?? true
+
+            switch (localChanged, remoteChanged) {
+            case (false, false):
+                break
+            case (true, false):
+                out.append(.push(noteID: note.id, existingFileName: file.fileName))
+            case (false, true):
+                out.append(.pull(fileName: file.fileName))
+            case (true, true):
+                let remoteDate = file.effectiveModified
+                guard note.modified != remoteDate else { break }   // the same edit, seen twice
+                out.append(.conflict(noteID: note.id, fileName: file.fileName,
+                                     localWins: note.modified > remoteDate))
+            }
+        }
+
+        // Identified files with no note behind them.
+        for file in remote.sorted(by: { $0.fileName < $1.fileName }) {
+            guard let id = file.noteID, !localIDs.contains(id) else { continue }
+            out.append(index.entries[id] == nil ? .pull(fileName: file.fileName)
+                                                : .deleteRemote(fileName: file.fileName))
+        }
+        return out
+    }
+}

--- a/Tests/CloudSyncTests.swift
+++ b/Tests/CloudSyncTests.swift
@@ -1,0 +1,480 @@
+import Foundation
+
+/// Checks for the iCloud Drive sync path: task round-tripping, the on-disk
+/// document format, folder naming, and the sync decision table.
+enum CloudSyncTests {
+    typealias Check = (Bool, String) -> Void
+
+    static func run(check: Check) {
+        testRenderWritesEveryField(check)
+        testRenderOmitsDerivedTitle(check)
+        testParseRoundTrip(check)
+        testParseAdoptsFileWithoutHeader(check)
+        testParseIgnoresUnknownKeysAndKeepsColonsInTitle(check)
+        testParseSurvivesABodyThatStartsWithAFence(check)
+        testParseFallsBackToTheFileName(check)
+        testAHorizontalRuleIsNotFrontMatter(check)
+        testAKeyValueBlockWithNoNotyKeysIsNotFrontMatter(check)
+        testFileNameSlugAndCollisions(check)
+        testAParenthesisedTitleIsNotMistakenForAConflictCopy(check)
+        testConflictCopiesLiveInASubdirectory(check)
+        testCoordinatedFileIO(check)
+        testPlaceholdersAreSeenAsUnresolved(check)
+        testIndexPersistence(check)
+        testPlanPushesANoteNeverSynced(check)
+        testPlanIsQuietWhenNothingChanged(check)
+        testPlanPushesALocalEdit(check)
+        testPlanPullsARemoteEdit(check)
+        testPlanAdoptsAFileWithNoIdentity(check)
+        testPlanDeletesBothWays(check)
+        testPlanDetectsConflictsAndPicksTheNewer(check)
+        testPlanSaysNothingAboutAnUnresolvedFile(check)
+        testACopiedDocumentBecomesItsOwnNote(check)
+        testTheIndexedDocumentIsTheOneThatKeepsTheIdentity(check)
+        testAMissingIndexEntryIsNotAConflictWhenBothSidesAgree(check)
+        testConflictDocumentHasNoIdentity(check)
+    }
+
+    // MARK: Rendering
+
+    /// A fixed, whole-second date so ISO 8601's lack of sub-second precision
+    /// cannot make a round-trip test flap.
+    private static let t0 = Date(timeIntervalSince1970: 1_757_000_000)
+    private static let t1 = Date(timeIntervalSince1970: 1_757_003_600)
+
+    private static func testRenderWritesEveryField(_ check: Check) {
+        var note = Note()
+        note.id = "FIXED-ID"
+        note.title = "Shopping"
+        note.body = "\(Tasks.openPrefix)milk\n\(Tasks.donePrefix)eggs"
+        note.color = 3
+        note.created = t0
+        note.modified = t1
+        note.archived = true
+        note.pinned = true
+        note.order = -2.5
+        note.textDirection = .rightToLeft
+
+        let expected = """
+        ---
+        noty-id: FIXED-ID
+        color: 3
+        created: \(NoteDocument.stamp.string(from: t0))
+        modified: \(NoteDocument.stamp.string(from: t1))
+        archived: true
+        pinned: true
+        order: -2.5
+        direction: rightToLeft
+        title: Shopping
+        ---
+
+        - [ ] milk
+        - [x] eggs
+        """
+        check(NoteDocument.render(note) == expected,
+              "render must write the full header and markdown-form tasks")
+    }
+
+    private static func testRenderOmitsDerivedTitle(_ check: Check) {
+        var note = Note()
+        note.title = ""
+        note.body = "just a body"
+        check(!NoteDocument.render(note).contains("\n\(NoteDocument.Key.title):"),
+              "a derived title is not a choice anyone made and must not be written out")
+    }
+
+    // MARK: Parsing
+
+    private static func testParseRoundTrip(_ check: Check) {
+        var note = Note()
+        note.id = "ROUND-TRIP"
+        note.title = "Custom: with a colon"
+        note.body = "\(Tasks.openPrefix)one\nplain\n\(Tasks.donePrefix)two"
+        note.color = 5
+        note.created = t0
+        note.modified = t1
+        note.archived = true
+        note.pinned = true
+        note.order = -4
+        note.textDirection = .leftToRight
+
+        let parsed = NoteDocument.parse(NoteDocument.render(note), fallbackTitle: "")
+        check(parsed.hasIdentity, "a rendered document must carry its identity")
+        check(parsed.note == note, "render then parse must return the identical note")
+    }
+
+    private static func testParseAdoptsFileWithoutHeader(_ check: Check) {
+        let parsed = NoteDocument.parse("# Groceries\n\n- [ ] milk",
+                                        fallbackTitle: "Groceries")
+        check(!parsed.hasIdentity, "a plain markdown file has no identity yet")
+        check(parsed.note.body == "# Groceries\n\n\(Tasks.openPrefix)milk",
+              "a headerless file is all body, with its tasks converted")
+        check(!parsed.note.hasCustomTitle,
+              "a title derivable from the body must stay derived")
+    }
+
+    private static func testParseIgnoresUnknownKeysAndKeepsColonsInTitle(_ check: Check) {
+        let text = """
+        ---
+        noty-id: KEEP
+        title: Ratio: 3:1
+        something-else: ignored
+        color: 2
+        ---
+
+        body
+        """
+        let parsed = NoteDocument.parse(text, fallbackTitle: "")
+        check(parsed.note.title == "Ratio: 3:1",
+              "a value must be split on the first colon only")
+        check(parsed.note.color == 2, "known keys after an unknown one must still parse")
+        check(parsed.note.body == "body", "unknown keys must not leak into the body")
+    }
+
+    private static func testParseSurvivesABodyThatStartsWithAFence(_ check: Check) {
+        var note = Note()
+        note.id = "FENCED"
+        note.body = "---\nan em dash rule opens this note\n---"
+        note.created = t0
+        note.modified = t0
+        let parsed = NoteDocument.parse(NoteDocument.render(note), fallbackTitle: "")
+        check(parsed.note.body == note.body,
+              "only the first closing fence ends the header")
+    }
+
+    private static func testParseFallsBackToTheFileName(_ check: Check) {
+        let parsed = NoteDocument.parse("", fallbackTitle: "Untitled from phone")
+        check(parsed.note.title == "Untitled from phone",
+              "an empty file takes its title from its filename")
+    }
+
+    private static func testAHorizontalRuleIsNotFrontMatter(_ check: Check) {
+        let text = """
+        ---
+        Intro line
+        ---
+        Body line
+        """
+        let parsed = NoteDocument.parse(text, fallbackTitle: "From phone")
+        check(!parsed.hasIdentity, "there is no identity in a note that opens with a rule")
+        check(parsed.note.body == text,
+              "a note that opens with a horizontal rule must survive intact")
+    }
+
+    private static func testAKeyValueBlockWithNoNotyKeysIsNotFrontMatter(_ check: Check) {
+        let text = """
+        ---
+        Author: someone
+        Mood: bright
+        ---
+        Body line
+        """
+        let parsed = NoteDocument.parse(text, fallbackTitle: "From phone")
+        check(parsed.note.body == text,
+              "somebody else's front matter is content, not something to swallow")
+    }
+
+    // MARK: Folder
+
+    private static func testFileNameSlugAndCollisions(_ check: Check) {
+        var note = Note()
+        note.title = "Trip / notes: 2026"
+        let first = CloudFolder.fileName(for: note, avoiding: [])
+        check(first == "Trip - notes- 2026.md",
+              "path-hostile characters must be replaced, not dropped")
+
+        note.title = "https://example.com/post?id=1"
+        check(CloudFolder.fileName(for: note, avoiding: []) == "https-example.com-post-id=1.md",
+              "a url title must not collapse into a run of dashes")
+        note.title = "//example.com"
+        check(CloudFolder.fileName(for: note, avoiding: []) == "example.com.md",
+              "a title of only separators must not leave leading dashes")
+        note.title = "Trip / notes: 2026"
+
+        let second = CloudFolder.fileName(for: note, avoiding: [first.lowercased()])
+        check(second == "Trip - notes- 2026-2.md", "a taken name must be suffixed")
+
+        var blank = Note()
+        blank.id = "ABCDEFGH-1234"
+        blank.title = ""
+        blank.body = ""
+        check(CloudFolder.fileName(for: blank, avoiding: []) == "note-ABCDEFGH.md",
+              "a note with no title falls back to its id")
+
+        var dotted = Note()
+        dotted.id = "ZYXWVUTS-9999"
+        dotted.title = ".hidden"
+        check(CloudFolder.fileName(for: dotted, avoiding: []) == "note-ZYXWVUTS.md",
+              "a leading dot would hide the file from the Files app")
+    }
+
+    private static func testAParenthesisedTitleIsNotMistakenForAConflictCopy(_ check: Check) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-conflict-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var note = Note()
+        note.title = "Refactor (conflict resolution)"
+        let name = CloudFolder.fileName(for: note, avoiding: [])
+        check(name == "Refactor (conflict resolution).md",
+              "a title with parentheses keeps them")
+
+        try? "x".write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        check(CloudFolder.scan(in: dir).documents[name] != nil,
+              "a note whose title merely reads like a conflict must stay visible")
+    }
+
+    private static func testConflictCopiesLiveInASubdirectory(_ check: Check) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-conflict2-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        check(CloudFolder.writeConflict("loser", named: "Shopping.md", in: dir),
+              "a conflict copy must be written")
+        let sidecars = (try? FileManager.default.contentsOfDirectory(
+            atPath: dir.appendingPathComponent(CloudFolder.conflictsFolderName).path)) ?? []
+        check(sidecars.count == 1, "the copy lands in the Conflicts subdirectory")
+        check(sidecars[0].hasPrefix("Shopping (conflict "),
+              "the copy names the note it came from")
+        check(CloudFolder.scan(in: dir).allNames.isEmpty,
+              "a conflict copy must never be enumerated as a note document")
+    }
+
+    private static func testPlaceholdersAreSeenAsUnresolved(_ check: Check) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-placeholder-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try? "hello".write(to: dir.appendingPathComponent("Present.md"),
+                           atomically: true, encoding: .utf8)
+        // What iCloud leaves behind when it evicts "Evicted.md".
+        try? "".write(to: dir.appendingPathComponent(".Evicted.md.icloud"),
+                      atomically: true, encoding: .utf8)
+        try? "".write(to: dir.appendingPathComponent(".DS_Store"),
+                      atomically: true, encoding: .utf8)
+
+        let scan = CloudFolder.scan(in: dir)
+        check(scan.documents["Present.md"] != nil, "a downloaded document is listed")
+        check(scan.unresolved.contains("Evicted.md"),
+              "an evicted document must be reported under its real name, not as missing")
+        check(!scan.allNames.contains(".DS_Store"),
+              "hidden files that are not placeholders must be ignored")
+        check(scan.allNames == ["Present.md", "Evicted.md"],
+              "the folder holds exactly these two documents")
+    }
+
+    private static func testCoordinatedFileIO(_ check: Check) {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-cloud-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let file = dir.appendingPathComponent("Shopping.md")
+        check(CloudFolder.write("hello", to: file), "write must report success")
+        check(CloudFolder.read(file) == "hello", "read must return what write stored")
+        check(CloudFolder.modificationDate(of: file) != nil, "a written file has a date")
+
+        let conflictName = CloudFolder.conflictName(for: "Shopping.md", at: t0)
+        let conflict = dir.appendingPathComponent(conflictName)
+        check(CloudFolder.write("loser", to: conflict), "conflict files are written the same way")
+        try? "not markdown".write(to: dir.appendingPathComponent("cover.png"),
+                                  atomically: true, encoding: .utf8)
+
+        let found = CloudFolder.documentURLs(in: dir).map(\.lastPathComponent)
+        check(found == [conflictName, "Shopping.md"],
+              "listing must keep markdown files and skip anything that is not .md")
+
+        check(CloudFolder.remove(file), "remove must report success")
+        check(CloudFolder.read(file) == nil, "a removed file cannot be read back")
+    }
+
+    // MARK: Index
+
+    private static func testIndexPersistence(_ check: Check) {
+        let file = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-index-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        var index = CloudSyncIndex()
+        index.record(noteID: "A", fileName: "Shopping.md", noteModified: t0, fileModified: t1)
+        index.save(to: file)
+
+        let loaded = CloudSyncIndex.load(from: file)
+        check(loaded.entries["A"]?.fileName == "Shopping.md", "an entry must survive a save/load")
+        check(loaded.entries["A"]?.syncedModified == t0, "the note date must survive")
+        check(loaded.entries["A"]?.fileModified == t1, "the file date must survive")
+        check(loaded.id(forFileName: "Shopping.md") == "A", "a filename must resolve to its id")
+        check(loaded.id(forFileName: "Missing.md") == nil, "an unknown filename resolves to nothing")
+
+        var trimmed = loaded
+        trimmed.forget(noteID: "A")
+        check(trimmed.entries.isEmpty, "forget must drop the entry")
+
+        let absent = CloudSyncIndex.load(
+            from: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("noty-index-does-not-exist.json"))
+        check(absent.entries.isEmpty, "a missing index file loads as an empty index")
+    }
+
+    // MARK: Planning
+
+    private static func testACopiedDocumentBecomesItsOwnNote(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            // The copy carries the original's header, mtime and all.
+            remote: [remote("Site.md", id: "A", declared: t0, file: t0),
+                     remote("Site copy.md", id: "A", declared: t0, file: t0)],
+            unresolved: [],
+            index: synced("A", "Site.md", noteDate: t0, fileDate: t0))
+        check(actions == [.adopt(fileName: "Site copy.md")],
+              "the copy must become a note of its own, not shadow the original")
+    }
+
+    private static func testTheIndexedDocumentIsTheOneThatKeepsTheIdentity(_ check: Check) {
+        // The copy sorts last and is newer, but the index already knows which
+        // document this note lives in. That one keeps the identity.
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            remote: [remote("Site.md", id: "A", declared: t0, file: t0),
+                     remote("zzz copy.md", id: "A", declared: t0, file: t1)],
+            unresolved: [],
+            index: synced("A", "Site.md", noteDate: t0, fileDate: t0))
+        check(actions == [.adopt(fileName: "zzz copy.md")],
+              "the document the index names keeps the identity, whatever the copy's date")
+    }
+
+    private static func note(_ id: String, modified: Date) -> Note {
+        var n = Note()
+        n.id = id
+        n.modified = modified
+        return n
+    }
+
+    private static func remote(_ name: String, id: String?,
+                               declared: Date, file: Date) -> SyncPlan.RemoteFile {
+        SyncPlan.RemoteFile(fileName: name, noteID: id,
+                            declaredModified: declared, fileModified: file)
+    }
+
+    private static func synced(_ id: String, _ name: String,
+                               noteDate: Date, fileDate: Date) -> CloudSyncIndex {
+        var index = CloudSyncIndex()
+        index.record(noteID: id, fileName: name, noteModified: noteDate, fileModified: fileDate)
+        return index
+    }
+
+    private static func testPlanPushesANoteNeverSynced(_ check: Check) {
+        let actions = SyncPlan.actions(notes: [note("A", modified: t0)],
+                                       remote: [], unresolved: [], index: CloudSyncIndex())
+        check(actions == [.push(noteID: "A", existingFileName: nil)], "an unsynced note with no file must be pushed")
+    }
+
+    private static func testPlanIsQuietWhenNothingChanged(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            remote: [remote("A.md", id: "A", declared: t0, file: t0)],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(actions.isEmpty, "an unchanged pair must produce no work")
+    }
+
+    private static func testPlanPushesALocalEdit(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t1)],
+            remote: [remote("A.md", id: "A", declared: t0, file: t0)],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(actions == [.push(noteID: "A", existingFileName: "A.md")], "a newer note must be pushed")
+    }
+
+    private static func testPlanPullsARemoteEdit(_ check: Check) {
+        // The header still says t0 — an editor on the phone does not update it.
+        // Only the file's own date moved.
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            remote: [remote("A.md", id: "A", declared: t0, file: t1)],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(actions == [.pull(fileName: "A.md")],
+              "a file touched by a foreign editor must be pulled")
+    }
+
+    private static func testPlanAdoptsAFileWithNoIdentity(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [], remote: [remote("From phone.md", id: nil, declared: .distantPast, file: t1)],
+            unresolved: [], index: CloudSyncIndex())
+        check(actions == [.adopt(fileName: "From phone.md")],
+              "a file with no noty-id is a new note from another device")
+    }
+
+    private static func testPlanDeletesBothWays(_ check: Check) {
+        let goneRemotely = SyncPlan.actions(
+            notes: [note("A", modified: t0)], remote: [],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(goneRemotely == [.deleteLocal(noteID: "A")],
+              "a synced note whose file vanished was deleted elsewhere")
+
+        let goneLocally = SyncPlan.actions(
+            notes: [], remote: [remote("A.md", id: "A", declared: t0, file: t0)],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(goneLocally == [.deleteRemote(fileName: "A.md")],
+              "a file whose note was deleted here must go")
+
+        let neverSeen = SyncPlan.actions(
+            notes: [], remote: [remote("A.md", id: "A", declared: t0, file: t0)],
+            unresolved: [], index: CloudSyncIndex())
+        check(neverSeen == [.pull(fileName: "A.md")],
+              "an identified file this Mac has never synced is a note to pull, not a deletion")
+    }
+
+    private static func testPlanDetectsConflictsAndPicksTheNewer(_ check: Check) {
+        let localNewer = SyncPlan.actions(
+            notes: [note("A", modified: t1)],
+            remote: [remote("A.md", id: "A", declared: t0, file: t0.addingTimeInterval(60))],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(localNewer == [.conflict(noteID: "A", fileName: "A.md", localWins: true)],
+              "both sides changed and the note is newer")
+
+        let remoteNewer = SyncPlan.actions(
+            notes: [note("A", modified: t0.addingTimeInterval(60))],
+            remote: [remote("A.md", id: "A", declared: t0, file: t1)],
+            unresolved: [], index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(remoteNewer == [.conflict(noteID: "A", fileName: "A.md", localWins: false)],
+              "both sides changed and the file is newer")
+    }
+
+    private static func testAMissingIndexEntryIsNotAConflictWhenBothSidesAgree(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            // The file declares the same modified the note has; iCloud set the
+            // file's own mtime later, which is normal and means nothing.
+            remote: [remote("A.md", id: "A", declared: t0, file: t1)],
+            unresolved: [],
+            index: CloudSyncIndex())          // the index was lost
+        check(actions == [.reindex(noteID: "A", fileName: "A.md")],
+              "an agreeing pair with no index entry must be recorded, not fought over")
+    }
+
+    private static func testPlanSaysNothingAboutAnUnresolvedFile(_ check: Check) {
+        let actions = SyncPlan.actions(
+            notes: [note("A", modified: t0)],
+            remote: [],                              // could not be read, so not here
+            unresolved: ["A.md"],
+            index: synced("A", "A.md", noteDate: t0, fileDate: t0))
+        check(actions.isEmpty,
+              "a note whose file exists but could not be read must produce no action")
+    }
+
+    private static func testConflictDocumentHasNoIdentity(_ check: Check) {
+        var note = Note()
+        note.id = "LOSER"
+        note.title = "Shopping"
+        note.body = "\(Tasks.openPrefix)milk"
+
+        let text = CloudSync.conflictDocument(for: note)
+        check(!text.contains(NoteDocument.Key.id),
+              "a conflict copy must carry no identity, or it would sync back as a note")
+        check(text.contains("# Shopping"), "a conflict copy names the note it came from")
+        check(text.contains("- [ ] milk"), "a conflict copy keeps the content it saved")
+    }
+}

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -25,6 +25,8 @@ struct EditorStyleEngineTests {
         testTextDirectionDatabaseMigration()
         LocalizationTests.run { check($0, $1) }
         TaskMarkerTests.run { check($0, $1) }
+        CloudSyncTests.run { check($0, $1) }
+        SyncRunnerTests.run { check($0, $1) }
         testCustomNoteTitleBehavior()
 
         guard failures == 0 else {

--- a/Tests/EditorStyleEngineTests.swift
+++ b/Tests/EditorStyleEngineTests.swift
@@ -24,6 +24,7 @@ struct EditorStyleEngineTests {
         testLegacyArchiveDefaultsToAutomaticDirection()
         testTextDirectionDatabaseMigration()
         LocalizationTests.run { check($0, $1) }
+        TaskMarkerTests.run { check($0, $1) }
         testCustomNoteTitleBehavior()
 
         guard failures == 0 else {

--- a/Tests/SyncRunnerTests.swift
+++ b/Tests/SyncRunnerTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+
+/// Drives the sync runner end to end against in-memory fakes. The runner is
+/// where every data-loss defect of the first implementation lived, precisely
+/// because it had no tests.
+enum SyncRunnerTests {
+    typealias Check = (Bool, String) -> Void
+
+    // MARK: Fakes
+
+    final class FakeFolder: SyncFolderGateway {
+        var isAvailable = true
+        var files: [String: String] = [:]
+        var dates: [String: Date] = [:]
+        /// Names present in the folder whose contents cannot be read this pass.
+        var unresolved: Set<String> = []
+        var conflicts: [String: String] = [:]
+        var removed: [String] = []
+
+        func ensureFolder() -> Bool { isAvailable }
+
+        func scan() -> FolderScan {
+            var out = FolderScan()
+            for (name, _) in files where !unresolved.contains(name) {
+                out.documents[name] = dates[name] ?? SyncRunnerTests.t0
+            }
+            out.unresolved = unresolved.intersection(Set(files.keys))
+            return out
+        }
+
+        /// Recorded so a later task can prove a quiet pass reads nothing.
+        var reads: [String] = []
+
+        func read(_ fileName: String) -> String? {
+            guard !unresolved.contains(fileName) else { return nil }
+            reads.append(fileName)
+            return files[fileName]
+        }
+
+        func modificationDate(of fileName: String) -> Date? { dates[fileName] }
+
+        @discardableResult
+        func write(_ text: String, named fileName: String) -> Bool {
+            files[fileName] = text
+            dates[fileName] = dates[fileName] ?? Date(timeIntervalSince1970: 1_757_000_000)
+            return true
+        }
+
+        @discardableResult
+        func remove(_ fileName: String) -> Bool {
+            removed.append(fileName)
+            files[fileName] = nil
+            dates[fileName] = nil
+            unresolved.remove(fileName)
+            return true
+        }
+
+        @discardableResult
+        func writeConflict(_ text: String, named fileName: String) -> Bool {
+            conflicts[fileName] = text
+            return true
+        }
+
+        /// Put a note in the folder exactly as the app would have written it.
+        func place(_ note: Note, named fileName: String, at date: Date) {
+            files[fileName] = NoteDocument.render(note)
+            dates[fileName] = date
+        }
+    }
+
+    final class FakeStore: NoteStoring {
+        var notes: [Note] = []
+        var deleted: [String] = []
+
+        var active: [Note] { notes.filter { !$0.archived }.sorted { $0.order < $1.order } }
+        func note(id: String) -> Note? { notes.first { $0.id == id } }
+
+        func absorb(_ note: Note) {
+            if let i = notes.firstIndex(where: { $0.id == note.id }) { notes[i] = note }
+            else { notes.append(note) }
+        }
+
+        func delete(id: String) {
+            deleted.append(id)
+            notes.removeAll { $0.id == id }
+        }
+    }
+
+    // MARK: Harness
+
+    static let t0 = Date(timeIntervalSince1970: 1_757_000_000)
+    static let t1 = Date(timeIntervalSince1970: 1_757_003_600)
+
+    /// A runner wired to fakes, with its index in a scratch file that is deleted
+    /// when `body` returns.
+    static func withRunner(folder: FakeFolder, store: FakeStore,
+                           _ body: (CloudSync, URL) -> Void) {
+        let indexURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("noty-sync-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: indexURL) }
+        let wasEnabled = Settings.cloudSyncEnabled
+        Settings.cloudSyncEnabled = true
+        defer { Settings.cloudSyncEnabled = wasEnabled }
+        body(CloudSync(folder: folder, store: store, indexURL: indexURL), indexURL)
+    }
+
+    static func note(_ id: String, title: String = "", body: String = "",
+                     modified: Date = t0) -> Note {
+        var n = Note()
+        n.id = id
+        n.title = title
+        n.body = body
+        n.created = modified
+        n.modified = modified
+        return n
+    }
+
+    private static func testAQuietPassReadsNothing(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Shopping", body: "milk")]
+
+        withRunner(folder: folder, store: store) { sync, indexURL in
+            sync.syncNow()
+            let firstIndex = try? Data(contentsOf: indexURL)
+            folder.reads.removeAll()
+
+            sync.syncNow()
+            check(folder.reads.isEmpty,
+                  "a pass where no file's date moved must not read any file")
+
+            let secondIndex = try? Data(contentsOf: indexURL)
+            check(firstIndex == secondIndex,
+                  "a pass that did nothing must not rewrite the index")
+        }
+    }
+
+    private static func testLosingTheIndexDoesNotRewriteEverything(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Shopping", body: "milk")]
+
+        withRunner(folder: folder, store: store) { sync, indexURL in
+            sync.syncNow()
+            check(folder.conflicts.isEmpty, "precondition: a clean first pass")
+
+            // The index file is lost. A fresh runner over the same folder and
+            // store must recognise that the two sides already agree.
+            try? FileManager.default.removeItem(at: indexURL)
+            let second = CloudSync(folder: folder, store: store, indexURL: indexURL)
+            second.syncNow()
+
+            check(folder.conflicts.isEmpty,
+                  "a lost index must not manufacture a conflict for every note")
+            check(store.note(id: "A")?.body == "milk", "the local note must not be reverted")
+        }
+    }
+
+    // MARK: Tests
+
+    static func run(check: Check) {
+        testFirstPassWritesEveryNote(check)
+        testAnUnreadableFileNeverDeletesItsNote(check)
+        testTwoNotesWithOneTitleGetTwoFiles(check)
+        testAPushDoesNotOverwriteAFileTheIndexNeverSaw(check)
+        testARenameOnThePhoneDoesNotBreedADuplicate(check)
+        testLosingTheIndexDoesNotRewriteEverything(check)
+        testAQuietPassReadsNothing(check)
+        testACopiedFileLandsOnTheDeckAsASecondNote(check)
+    }
+
+    private static func testARenameOnThePhoneDoesNotBreedADuplicate(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Todo", body: "one")]
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            sync.syncNow()
+            check(folder.files["Todo.md"] != nil, "precondition: the note was written")
+
+            // Renamed in the Files app. A rename does not change the contents,
+            // so the mtime the app recorded still stands.
+            let text = folder.files.removeValue(forKey: "Todo.md")!
+            let date = folder.dates.removeValue(forKey: "Todo.md")!
+            folder.files["Groceries.md"] = text
+            folder.dates["Groceries.md"] = date
+
+            // Now edit the note locally, which forces a push.
+            store.notes[0].body = "two"
+            store.notes[0].modified = t1
+            sync.syncNow()
+
+            check(folder.files["Todo.md"] == nil,
+                  "the push must not resurrect the name the phone renamed away from")
+            check(folder.files.count == 1,
+                  "one note must never end up as two files sharing one noty-id")
+            check(folder.files["Groceries.md"]?.contains("two") == true,
+                  "the edit must land in the file the phone actually has")
+        }
+    }
+
+    private static func testTwoNotesWithOneTitleGetTwoFiles(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Ideas", body: "first"),
+                       note("B", title: "Ideas", body: "second")]
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            sync.syncNow()
+            check(folder.files.count == 2,
+                  "two notes must never share one file — the second would overwrite the first")
+            let bodies = Set(folder.files.values.map { $0.contains("first") })
+            check(bodies == [true, false], "both notes' contents must survive")
+        }
+    }
+
+    /// A name the folder holds but the index has never seen — a file created on
+    /// another device while this Mac was offline. Allocating against the index
+    /// alone let a push overwrite it.
+    private static func testAPushDoesNotOverwriteAFileTheIndexNeverSaw(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Ideas", body: "mine")]
+        var phone = Note()
+        phone.id = "PHONE"
+        phone.body = "theirs"
+        phone.created = t0
+        phone.modified = t0
+        folder.place(phone, named: "Ideas.md", at: t0)
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            sync.syncNow()
+            check(folder.files.values.contains(where: { $0.contains("theirs") }),
+                  "a file the index never saw must not be overwritten")
+            check(folder.files.values.contains(where: { $0.contains("mine") }),
+                  "the local note must still be written out")
+        }
+    }
+
+    /// The defect that motivated this plan: with "Optimize Mac Storage" on,
+    /// iCloud evicts file contents. A pass that cannot read a file must say
+    /// nothing about it at all.
+    private static func testAnUnreadableFileNeverDeletesItsNote(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Shopping", body: "milk")]
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            sync.syncNow()                              // first pass writes Shopping.md
+            check(folder.files["Shopping.md"] != nil, "precondition: the file was written")
+
+            folder.unresolved.insert("Shopping.md")     // iCloud evicts the contents
+            sync.syncNow()
+
+            check(store.deleted.isEmpty,
+                  "an unreadable file must never delete the note behind it")
+            check(store.note(id: "A") != nil, "the note must still be in the store")
+            check(!folder.removed.contains("Shopping.md"),
+                  "an unreadable file must not be removed either")
+        }
+    }
+
+    private static func testFirstPassWritesEveryNote(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Shopping", body: "milk")]
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            check(sync.syncNow(), "a pass with an available folder must run")
+            check(folder.files["Shopping.md"] != nil,
+                  "the note must be written out under its title")
+            check(folder.files["Shopping.md"]?.contains("noty-id: A") == true,
+                  "the written document must carry the note's identity")
+            check(store.deleted.isEmpty, "a first pass must never delete anything")
+        }
+    }
+
+    private static func testACopiedFileLandsOnTheDeckAsASecondNote(_ check: Check) {
+        let folder = FakeFolder()
+        let store = FakeStore()
+        store.notes = [note("A", title: "Site", body: "one")]
+
+        withRunner(folder: folder, store: store) { sync, _ in
+            sync.syncNow()
+            check(folder.files["Site.md"] != nil, "precondition: the note was written")
+
+            // Duplicated in the Files app: the header travels with the body, and
+            // a Finder copy keeps the modification date too.
+            folder.files["Site 2.md"] = folder.files["Site.md"]
+            folder.dates["Site 2.md"] = folder.dates["Site.md"]
+            sync.syncNow()
+
+            check(store.notes.count == 2, "the copy must land on the deck as a second note")
+            check(Set(store.notes.map(\.id)).count == 2,
+                  "the two notes must not share an identity")
+            check(folder.files["Site 2.md"]?.contains("noty-id: A") == false,
+                  "the copy's file must be rewritten with its own identity")
+            check(folder.files["Site.md"]?.contains("noty-id: A") == true,
+                  "the original must keep the identity the index knows")
+            check(store.deleted.isEmpty, "nothing may be deleted to resolve a duplicate")
+        }
+    }
+
+}

--- a/Tests/TaskMarkerTests.swift
+++ b/Tests/TaskMarkerTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Checks that ☐/☑ task markers and Markdown task syntax convert on every line,
+/// in both directions.
+enum TaskMarkerTests {
+    typealias Check = (Bool, String) -> Void
+
+    static func run(check: Check) {
+        testEveryTaskLineConverts(check)
+        testMidLineMarkerIsNotATask(check)
+        testTaskRoundTrip(check)
+    }
+
+    private static func testEveryTaskLineConverts(_ check: Check) {
+        let markdown = """
+        - [ ] first
+        - [x] second
+          - [ ] indented third
+        not a task
+        """
+        let expected = """
+        \(Tasks.openPrefix)first
+        \(Tasks.donePrefix)second
+          \(Tasks.openPrefix)indented third
+        not a task
+        """
+        check(Tasks.fromMarkdown(markdown) == expected,
+              "every markdown task line must convert, not only the first")
+    }
+
+    private static func testMidLineMarkerIsNotATask(_ check: Check) {
+        let body = "the \(Tasks.open) glyph used mid-sentence"
+        check(Tasks.toMarkdown(body) == body,
+              "a marker in the middle of a line is text, not a task")
+    }
+
+    private static func testTaskRoundTrip(_ check: Check) {
+        let body = """
+        \(Tasks.openPrefix)open
+        \(Tasks.donePrefix)done
+        a plain line
+          \(Tasks.openPrefix)nested
+        """
+        check(Tasks.fromMarkdown(Tasks.toMarkdown(body)) == body,
+              "tasks must survive a markdown round trip unchanged")
+    }
+}

--- a/scripts/test-editor.sh
+++ b/scripts/test-editor.sh
@@ -20,6 +20,8 @@ swiftc -parse-as-library -swift-version 5 \
     "${APP_SOURCES[@]}" \
     "$ROOT/Tests/LocalizationTests.swift" \
     "$ROOT/Tests/TaskMarkerTests.swift" \
+    "$ROOT/Tests/CloudSyncTests.swift" \
+    "$ROOT/Tests/SyncRunnerTests.swift" \
     "$ROOT/Tests/EditorStyleEngineTests.swift" \
     -o "$OUT/EditorStyleEngineTests"
 

--- a/scripts/test-editor.sh
+++ b/scripts/test-editor.sh
@@ -19,6 +19,7 @@ swiftc -parse-as-library -swift-version 5 \
     -sdk "$SDK" \
     "${APP_SOURCES[@]}" \
     "$ROOT/Tests/LocalizationTests.swift" \
+    "$ROOT/Tests/TaskMarkerTests.swift" \
     "$ROOT/Tests/EditorStyleEngineTests.swift" \
     -o "$OUT/EditorStyleEngineTests"
 


### PR DESCRIPTION
Opt-in, two-way sync between the deck and a folder in iCloud Drive. Each note
becomes one Markdown file with a small front-matter header; the folder opens in
Files on a phone and the notes edit in any Markdown editor. Edits travel both
ways, files written on the phone become notes, and deletions propagate.

No Apple Developer account, no entitlements, no iOS app, no server.

Targets `dev`, per the branch policy in the README.

## Why the iCloud Drive folder and not CloudKit

CloudKit was the first thing I tried to justify, and it does not fit this
project:

- `CKContainer(identifier:)` requires the identifier to be listed in the app's
  `com.apple.developer.icloud-container-identifiers` entitlement.
- Adding the iCloud capability requires an active Apple Developer Program
  membership, an Xcode project and a provisioning profile.
- This repository has no `.entitlements` file, no Xcode project, and signs
  ad-hoc by default (`build.sh`, `IDENTITY="${CODESIGN_IDENTITY:--}"`).
- An unentitled call fails at runtime with `CKError.missingEntitlement`.

That is the same wall that keeps the app unsandboxed, and it would also require
writing an iOS app from scratch — a separate product, not a feature of this one.

`~/Library/Mobile Documents/com~apple~CloudDocs/` is an ordinary directory. A
non-sandboxed app reads and writes it with no entitlement, and the system's own
daemon does the syncing. That is the whole mechanism.

## The file format

```
---
noty-id: 8E3C1F0A-...
color: 3
created: 2026-09-06T10:00:00Z
modified: 2026-09-06T10:05:00Z
archived: false
pinned: false
order: -3
direction: automatic
title: A custom title
---

# First line of the body

- [ ] an open task
- [x] a finished task
```

Identity lives in the header, never in the filename, so renaming a file on the
phone does not create a duplicate. `title` is written only when the note has a
custom one — an empty title still means "derive it from the first line", which
is the model's own rule. Tasks are stored as Markdown task syntax on disk and
converted to the in-app `☐` / `☑` prefixes on the way in.

A file with no header is a note somebody wrote on their phone: it is adopted,
given an id, and the header is written back.

## How it works

- **`SyncPlan.actions` is pure.** `(notes, folder contents, last-sync index) →
  [Action]`. No file system, no clock, no `NoteStore`. The whole decision table
  is unit-tested.
- **`CloudSync` performs the actions** through a `SyncFolderGateway` and a
  `NoteStoring` protocol, so the runner is driven in tests by in-memory fakes.
- **`CloudSyncIndex`** records what the last pass saw. It lives in Application
  Support, never in the synced folder, so a second Mac cannot fight over it.
- **Deletion follows from evidence.** A note is only deleted when its document
  is confirmed absent from the folder listing. An unreadable file, a failed
  read, an evicted `.Name.md.icloud` placeholder — none of those count as
  absence, and placeholders get a download requested instead.
- **Conflicts keep both versions.** The newer `modified` wins; the loser is
  written to `Noty/Conflicts/` as a plain document with no identity, so it
  never syncs back and never becomes a second note.
- **A quiet pass is a directory listing.** A document whose modification date
  matches the index is described from the index rather than re-read, and the
  index is only rewritten when a pass actually did something.

## The privacy trade-off — this is the part worth arguing about

The README currently promises, in its own section, that notes never leave the
Mac. This feature makes that conditional, and I did not want to slip that past
you:

- It is **off by default** and takes an explicit switch in Settings → Sync.
- With it off, nothing is written outside `~/Library/Application Support/Noty/`.
- With it on, the files in iCloud Drive are **plaintext**. They have to be, or
  nothing on the phone could open them.
- The SQLite database on the Mac stays AES-GCM encrypted either way.
- The Settings pane states this in as many words, and the README section is
  corrected in the same change rather than left stale.

If you would rather the app not offer this at all on those grounds, that is a
legitimate call and I would rather hear it before you spend time on the diff.

## What this looks like on the phone

Reading needs nothing — Files renders Markdown in Quick Look. Editing needs an
editor that writes **in place**, since sync notices a change by the file's own
modification date: Taio, Runestone, Textastic and Obsidian all qualify. An
editor that takes a copy through an "Open in…" share sheet leaves a second file
carrying the same `noty-id`, which is the limitation below.

Writing a note on the phone needs no knowledge of the format: an ordinary `.md`
file with one line of text is picked up, given an id, and the header is written
back into it. The README covers this.

## Also fixes a pre-existing bug

`Tasks.fromMarkdown` and `Tasks.toMarkdown` used
`String.replacingOccurrences(options: .regularExpression)`, which cannot request
`.anchorsMatchLines`. `^` therefore matched only the start of the whole string,
so importing a Markdown file with three tasks converted only the first one;
`toMarkdown` was not anchored at all, so a `☐` used mid-sentence became list
syntax. Both now go through `NSRegularExpression` with `.anchorsMatchLines`, and
round-tripping is covered by tests.

This one is independent of sync and I am happy to split it into its own PR if
you would prefer to take it separately.

## Testing

`./scripts/test-editor.sh` — the existing suite, extended with two new files.
The suite passes and `./build.sh release` signs cleanly.

The design exists to make this testable. `SyncPlan.actions` is a pure function,
so the decision table is exercised directly, and the runner talks to the world
through two protocols, so it runs end-to-end against in-memory fakes.

Sync gets a great many chances to destroy somebody's notes, so the destructive
cases are enumerated and pinned by tests rather than left to judgement:

| Case | Guaranteed behaviour |
|---|---|
| A file's contents are evicted by "Optimize Mac Storage" | The note is untouched; a download is requested |
| A read fails between listing and reading | The note is untouched |
| Two notes carry the same title | Two files; neither overwrites the other |
| A note's title merely reads like a conflict copy | Still a normal note |
| A file is renamed on the phone | The edit lands in the renamed file; no duplicate |
| A file is duplicated on the phone | The copy becomes a second note with its own id |
| `cloud-index.json` is lost or corrupted | Nothing reverts; no conflict copies are manufactured |
| A note written on the phone opens with `---` | Its first lines survive |
| A note is open in an editor when a pull arrives | The editor follows; the phone's edit is not overwritten |
| iCloud Drive is signed out | Sync disables itself and touches nothing |

The branch was written first and then reviewed adversarially; ten defects came
out of that review, seven of which lost notes, and each one is fixed with the
test that catches it. The table above is that review's residue.

## Scope

20 files, +1979 / -13. No new dependencies; Sparkle remains the only one.

Discussed first in #32.